### PR TITLE
Fix cargo build issues

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,7 +53,7 @@ uuid = { version = "1.0", features = ["v4", "serde"] }
 chrono = { version = "0.4", features = ["serde"] }
 
 # HTTP client and OAuth2
-reqwest = { version = "0.11", features = ["json", "stream"] }
+reqwest = { version = "0.11", default-features = false, features = ["json", "stream", "rustls-tls"] }
 oauth2 = "4.4"
 url = "2.5"
 tokio-util = { version = "0.7", features = ["io"] }


### PR DESCRIPTION
Replace native-tls with rustls-tls for reqwest to avoid requiring system OpenSSL development libraries (-lssl, -lcrypto). This makes the build work without needing to install libssl-dev/openssl-devel.