### PR TITLE
Add browser authentication to gdrive-auth

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -69,3 +69,6 @@ rusqlite = { version = "0.31", features = ["bundled"] }
 tauri = { version = "2.0", features = [] }
 tauri-build = { version = "2.0", features = [] }
 fuser = "0.14"
+
+# Browser opening
+open = "5.3"

--- a/tools/cli/Cargo.toml
+++ b/tools/cli/Cargo.toml
@@ -22,3 +22,5 @@ tracing-subscriber.workspace = true
 anyhow.workspace = true
 chrono.workspace = true
 rpassword = "7.0"
+open.workspace = true
+url.workspace = true


### PR DESCRIPTION
Add user-friendly OAuth2 flow that automatically opens the browser and captures the authorization callback via a local HTTP server:

- Automatically opens the default browser with auth URL
- Starts local server on port 8080 to capture OAuth callback
- Validates CSRF token for security
- Shows friendly HTML success/error pages in browser
- Falls back to manual URL copy if browser cannot be opened
- Provides clear terminal feedback throughout the process