### PR TITLE
Fix missing axiomvault-desktop package in workspace

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ members = [
     "core/ffi",
     "core/fuse",
     "tools/cli",
-    # "clients/desktop/src-tauri", # Requires GTK3 dev libraries
+    "clients/desktop/src-tauri",
 ]
 
 [workspace.package]


### PR DESCRIPTION
Enable axiomvault-desktop in the workspace by uncommenting it from the members list. This allows cargo run --package axiomvault-desktop to work on systems with required dependencies installed.