### PR TITLE
Fix iOS Rust build target installation error

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -8,4 +8,7 @@ targets = [
     "x86_64-unknown-linux-gnu",
     "aarch64-apple-darwin",
     "x86_64-apple-darwin",
+    "aarch64-apple-ios",
+    "aarch64-apple-ios-sim",
+    "x86_64-apple-ios",
 ]


### PR DESCRIPTION
This fixes the 'can't find crate for core' error when building iOS targets. The toolchain file now includes aarch64-apple-ios, aarch64-apple-ios-sim, and x86_64-apple-ios targets to ensure they are properly registered with cargo.