### PR TITLE
Fix desktop build linking errors

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,16 @@
+# Cargo configuration for AxiomVault
+# This file configures linker settings for proper system library discovery
+
+[target.x86_64-unknown-linux-gnu]
+# Tell the linker where to find system libraries
+# This is needed because lld doesn't search standard paths by default
+rustflags = [
+    "-C", "link-arg=-L/usr/lib64",
+    "-C", "link-arg=-L/usr/lib",
+    "-C", "link-arg=-L/lib64",
+    "-C", "link-arg=-L/lib",
+]
+
+[env]
+# Also set LIBRARY_PATH as a fallback
+LIBRARY_PATH = { value = "/usr/lib64:/usr/lib:/lib64:/lib", force = true }


### PR DESCRIPTION
The Rust toolchain uses lld by default on Linux x86_64, which doesn't search standard system library paths like /usr/lib64. This causes linking failures for the desktop build when GTK and other system libraries cannot be found.

This configuration adds the standard library paths to the linker search path, resolving the "unable to find library" errors.