### PR TITLE
Fix desktop linking symbol lookup error

### DIFF
--- a/clients/desktop/README.md
+++ b/clients/desktop/README.md
@@ -92,7 +92,44 @@ Note: Direct cargo builds may show cryptic errors if system dependencies are mis
 ```bash
 # Run the desktop application
 cargo run --package axiomvault-desktop
+
+# Or use the launcher script (handles library conflicts automatically)
+./run-desktop.sh
 ```
+
+### Troubleshooting: Library Conflicts with Conda
+
+If you see an error like:
+```
+symbol lookup error: /lib64/libjson-glib-1.0.so.0: undefined symbol: g_once_init_leave_pointer
+```
+
+This is caused by conda's GLib libraries conflicting with system libraries. Solutions:
+
+1. **Use the launcher script** (recommended):
+   ```bash
+   ./run-desktop.sh
+   ```
+
+2. **Deactivate conda** before running:
+   ```bash
+   conda deactivate
+   ./target/debug/axiomvault-desktop
+   ```
+
+3. **Force system libraries**:
+   ```bash
+   # Fedora/RHEL
+   LD_LIBRARY_PATH=/usr/lib64:$LD_LIBRARY_PATH ./target/debug/axiomvault-desktop
+
+   # Debian/Ubuntu
+   LD_LIBRARY_PATH=/usr/lib/x86_64-linux-gnu:$LD_LIBRARY_PATH ./target/debug/axiomvault-desktop
+   ```
+
+4. **Update conda's glib** (if you need conda active):
+   ```bash
+   conda update glib
+   ```
 
 ## Architecture
 

--- a/clients/desktop/run-desktop.sh
+++ b/clients/desktop/run-desktop.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+# Launcher script for AxiomVault Desktop
+# Resolves GLib library conflicts with conda environments
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+BINARY="$PROJECT_ROOT/target/debug/axiomvault-desktop"
+
+# Check if binary exists
+if [ ! -f "$BINARY" ]; then
+    echo "Error: Binary not found at $BINARY"
+    echo "Please build first with: cargo build -p axiomvault-desktop"
+    exit 1
+fi
+
+# Detect if conda is active and might cause library conflicts
+if [ -n "$CONDA_PREFIX" ] || [ -n "$CONDA_DEFAULT_ENV" ]; then
+    echo "Note: Conda environment detected. Adjusting library paths to avoid conflicts..."
+
+    # Prioritize system libraries over conda libraries
+    # This fixes the g_once_init_leave_pointer symbol issue
+    if [ -d "/usr/lib64" ]; then
+        export LD_LIBRARY_PATH="/usr/lib64:/usr/lib:${LD_LIBRARY_PATH}"
+    elif [ -d "/usr/lib/x86_64-linux-gnu" ]; then
+        export LD_LIBRARY_PATH="/usr/lib/x86_64-linux-gnu:/usr/lib:${LD_LIBRARY_PATH}"
+    fi
+fi
+
+# Run the application
+exec "$BINARY" "$@"


### PR DESCRIPTION
The desktop app fails with 'undefined symbol: g_once_init_leave_pointer' when conda environments inject older GLib libraries. This adds:
- run-desktop.sh: Launcher that prioritizes system libraries
- README: Troubleshooting section for conda library conflicts