### PR TITLE
fix: reqwest 0.13 compatibility + AXIOMVAULT_PASSWORD env var

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -56,7 +56,7 @@ uuid = { version = "1.0", features = ["v4", "serde"] }
 chrono = { version = "0.4", features = ["serde"] }
 
 # HTTP client and OAuth2
-reqwest = { version = "0.13", default-features = false, features = ["json", "stream", "rustls-tls"] }
+reqwest = { version = "0.13", default-features = false, features = ["json", "stream", "rustls", "query"] }
 oauth2 = "4.4"
 url = "2.5"
 tokio-util = { version = "0.7", features = ["io"] }

--- a/tools/cli/src/main.rs
+++ b/tools/cli/src/main.rs
@@ -322,6 +322,12 @@ async fn main() -> Result<()> {
 
 /// Prompt for password securely.
 fn prompt_password(prompt: &str) -> Result<Vec<u8>> {
+    // Allow non-interactive use via environment variable (useful for scripting/testing)
+    if let Ok(pw) = std::env::var("AXIOMVAULT_PASSWORD") {
+        if !pw.is_empty() {
+            return Ok(pw.into_bytes());
+        }
+    }
     let password = rpassword::prompt_password(prompt).context("Failed to read password")?;
     Ok(password.into_bytes())
 }


### PR DESCRIPTION
## Changes

### Bug Fix: reqwest 0.13 feature flags
- `rustls-tls` was renamed to `rustls` in reqwest 0.13
- `query()` on `RequestBuilder` is now behind the `query` feature flag

Without these fixes the crate fails to compile entirely.

### Feature: `AXIOMVAULT_PASSWORD` environment variable
Added env var support to `prompt_password()` for non-interactive use:
```bash
export AXIOMVAULT_PASSWORD=mysecret
axiomvault create --name myvault --path ./vault
```
Useful for CI pipelines, scripting, and automated testing.

## Testing
Full CLI smoke test passed on Linux arm64:
- `create` ✅
- `info` ✅  
- `mkdir` ✅
- `add` ✅
- `list` ✅
- `extract` ✅ (content verified)