### PR TITLE
feat: drag and drop file/folder import

### DIFF
--- a/clients/apple/AxiomVault-iOS/Sources/Views/VaultBrowserView.swift
+++ b/clients/apple/AxiomVault-iOS/Sources/Views/VaultBrowserView.swift
@@ -1,4 +1,5 @@
 import SwiftUI
+import UniformTypeIdentifiers
 
 struct VaultBrowserView: View {
     @EnvironmentObject var vaultManager: VaultManager
@@ -8,6 +9,7 @@ struct VaultBrowserView: View {
     @State private var showingChangePassword = false
     @State private var selectedEntry: VaultEntry?
     @State private var showingExportSheet = false
+    @State private var isDragTargeted = false
 
     var body: some View {
         VStack(spacing: 0) {
@@ -55,9 +57,37 @@ struct VaultBrowserView: View {
         .sheet(isPresented: $showingCreateDirectory) { CreateDirectoryView() }
         .sheet(isPresented: $showingVaultInfo) { VaultInfoView() }
         .sheet(isPresented: $showingChangePassword) { ChangePasswordView() }
+        .onDrop(of: [.fileURL], isTargeted: $isDragTargeted) { providers in
+            handleDrop(providers)
+            return true
+        }
+        .overlay {
+            if isDragTargeted {
+                RoundedRectangle(cornerRadius: 12)
+                    .strokeBorder(Color.accentColor, style: StrokeStyle(lineWidth: 3, dash: [8]))
+                    .background(Color.accentColor.opacity(0.1))
+                    .allowsHitTesting(false)
+            }
+        }
         .onAppear {
             if vaultManager.entries.isEmpty {
                 Task { await vaultManager.refreshEntries() }
+            }
+        }
+    }
+
+    private func handleDrop(_ providers: [NSItemProvider]) {
+        for provider in providers {
+            provider.loadItem(forTypeIdentifier: UTType.fileURL.identifier, options: nil) { item, _ in
+                guard let data = item as? Data,
+                      let url = URL(dataRepresentation: data, relativeTo: nil)
+                else { return }
+
+                Task { @MainActor in
+                    guard url.startAccessingSecurityScopedResource() else { return }
+                    defer { url.stopAccessingSecurityScopedResource() }
+                    await vaultManager.addFile(from: url)
+                }
             }
         }
     }

--- a/clients/apple/AxiomVault-macOS/Sources/Views/VaultBrowserView.swift
+++ b/clients/apple/AxiomVault-macOS/Sources/Views/VaultBrowserView.swift
@@ -9,6 +9,7 @@ struct VaultBrowserView: View {
     @State private var showChangePassword = false
     @State private var selectedEntries: Set<UUID> = []
     @State private var sortOrder = [KeyPathComparator(\VaultEntry.name)]
+    @State private var isDragTargeted = false
 
     var body: some View {
         VStack(spacing: 0) {
@@ -74,8 +75,41 @@ struct VaultBrowserView: View {
         .sheet(isPresented: $showChangePassword) {
             ChangePasswordSheet()
         }
+        .onDrop(of: [.fileURL], isTargeted: $isDragTargeted) { providers in
+            handleDrop(providers)
+            return true
+        }
+        .overlay {
+            if isDragTargeted {
+                RoundedRectangle(cornerRadius: 8)
+                    .strokeBorder(Color.accentColor, style: StrokeStyle(lineWidth: 3, dash: [8]))
+                    .background(Color.accentColor.opacity(0.1))
+                    .allowsHitTesting(false)
+            }
+        }
         .onAppear {
             Task { await vaultManager.refreshEntries() }
+        }
+    }
+
+    private func handleDrop(_ providers: [NSItemProvider]) {
+        var urls: [URL] = []
+        let group = DispatchGroup()
+
+        for provider in providers {
+            group.enter()
+            provider.loadItem(forTypeIdentifier: UTType.fileURL.identifier, options: nil) { item, _ in
+                defer { group.leave() }
+                guard let data = item as? Data,
+                      let url = URL(dataRepresentation: data, relativeTo: nil)
+                else { return }
+                urls.append(url)
+            }
+        }
+
+        group.notify(queue: .main) {
+            guard !urls.isEmpty else { return }
+            Task { await vaultManager.addFiles(from: urls) }
         }
     }
 


### PR DESCRIPTION
## Summary
- Drop files or folders from Finder (macOS) or Files app (iOS) directly into the vault browser
- Dashed border highlight shows the drop target on drag hover
- Reuses existing `addFiles`/`addFile` which already handle recursive folder import
- Works on both the file table and empty state views

## Test plan
- [ ] macOS: drag files from Finder into vault browser — files appear after drop
- [ ] macOS: drag a folder from Finder — folder and contents imported recursively
- [ ] macOS: dashed blue border appears while dragging over the vault area
- [ ] iOS: drag files from Files app in split view — files import correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)