### PR TITLE
fix: use macOS 13-compatible onChange(of:) overload

### DIFF
--- a/clients/apple/AxiomVault-macOS/Sources/Views/MainView.swift
+++ b/clients/apple/AxiomVault-macOS/Sources/Views/MainView.swift
@@ -39,7 +39,7 @@ struct MainView: View {
         .onAppear {
             syncManager.setActiveVault(vaultManager.vaultInfo?.vaultId)
         }
-        .onChange(of: vaultManager.vaultInfo?.vaultId) { _, newValue in
+        .onChange(of: vaultManager.vaultInfo?.vaultId) { newValue in
             syncManager.setActiveVault(newValue)
         }
         .onReceive(NotificationCenter.default.publisher(for: .createVault)) { _ in


### PR DESCRIPTION
## Summary

- Replace the macOS 14-only `onChange(of:initial:_:)` two-parameter closure with the macOS 13-compatible `onChange(of:perform:)` single-parameter form in `MainView.swift`
- The project deployment target is macOS 13.0, so this API was breaking builds

Closes #118

## Test plan

- [ ] Build the macOS client with deployment target set to macOS 13.0
- [ ] Verify vault switching still triggers `syncManager.setActiveVault` correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)