### PR TITLE
fix: use iOS 16-compatible onChange(of:) overload

### DIFF
--- a/clients/apple/AxiomVault-iOS/Sources/Views/ContentView.swift
+++ b/clients/apple/AxiomVault-iOS/Sources/Views/ContentView.swift
@@ -38,7 +38,7 @@ struct ContentView: View {
         .onAppear {
             syncManager.setActiveVault(vaultManager.vaultInfo?.vaultId)
         }
-        .onChange(of: vaultManager.vaultInfo?.vaultId) { _, newValue in
+        .onChange(of: vaultManager.vaultInfo?.vaultId) { newValue in
             syncManager.setActiveVault(newValue)
         }
         .alert("Error", isPresented: .constant(vaultManager.errorMessage != nil)) {


### PR DESCRIPTION
## Summary
- Use single-parameter `onChange(of:)` closure to match the iOS 16.0 deployment target
- Same fix as #119 applied for macOS 13 compatibility

## Test plan
- [ ] Verify the iOS app builds without warnings targeting iOS 16.0

🤖 Generated with [Claude Code](https://claude.com/claude-code)