### PR TITLE
feat(webdav): add WebDAV server as FUSE fallback for vault access

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -252,6 +252,7 @@ dependencies = [
  "axiomvault-storage",
  "axiomvault-sync",
  "axiomvault-vault",
+ "axiomvault-webdav",
  "chrono",
  "clap",
  "clap_complete",
@@ -414,6 +415,80 @@ dependencies = [
  "tracing",
  "uuid",
  "zeroize",
+]
+
+[[package]]
+name = "axiomvault-webdav"
+version = "0.1.0"
+dependencies = [
+ "axiomvault-common",
+ "axiomvault-crypto",
+ "axiomvault-storage",
+ "axiomvault-vault",
+ "axum",
+ "chrono",
+ "http",
+ "http-body-util",
+ "hyper",
+ "percent-encoding",
+ "reqwest 0.13.2",
+ "serde_json",
+ "tempfile",
+ "thiserror 2.0.18",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "axum"
+version = "0.8.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b52af3cb4058c895d37317bb27508dccc8e5f2d39454016b297bf4a400597b8"
+dependencies = [
+ "axum-core",
+ "bytes",
+ "form_urlencoded",
+ "futures-util",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-util",
+ "itoa",
+ "matchit",
+ "memchr",
+ "mime",
+ "percent-encoding",
+ "pin-project-lite",
+ "serde_core",
+ "serde_json",
+ "serde_path_to_error",
+ "serde_urlencoded",
+ "sync_wrapper",
+ "tokio",
+ "tower",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "axum-core"
+version = "0.5.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08c78f31d7b1291f7ee735c1c6780ccde7785daae9a9206026862dab7d8792d1"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "http",
+ "http-body",
+ "http-body-util",
+ "mime",
+ "pin-project-lite",
+ "sync_wrapper",
+ "tower-layer",
+ "tower-service",
+ "tracing",
 ]
 
 [[package]]
@@ -2207,6 +2282,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
 
 [[package]]
+name = "httpdate"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
+
+[[package]]
 name = "hyper"
 version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2219,6 +2300,7 @@ dependencies = [
  "http",
  "http-body",
  "httparse",
+ "httpdate",
  "itoa",
  "pin-project-lite",
  "smallvec",
@@ -2853,6 +2935,12 @@ name = "matches"
 version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2532096657941c2fea9c289d370a250971c689d4f143798ff67113ec042024a5"
+
+[[package]]
+name = "matchit"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47e1ffaa40ddd1f3ed91f717a33c8c0ee23fff369e3aa8772b9605cc1d22f4c3"
 
 [[package]]
 name = "memchr"
@@ -5574,6 +5662,7 @@ dependencies = [
  "tokio",
  "tower-layer",
  "tower-service",
+ "tracing",
 ]
 
 [[package]]
@@ -5612,6 +5701,7 @@ version = "0.1.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100"
 dependencies = [
+ "log",
  "pin-project-lite",
  "tracing-attributes",
  "tracing-core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,7 @@ members = [
     "core/app",
     "core/ffi",
     "core/fuse",
+    "core/webdav",
     "tools/cli",
     "clients/desktop/src-tauri",
     "clients/linux",

--- a/core/webdav/Cargo.toml
+++ b/core/webdav/Cargo.toml
@@ -1,0 +1,35 @@
+[package]
+name = "axiomvault-webdav"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+
+[dependencies]
+axiomvault-common = { path = "../common" }
+axiomvault-vault = { path = "../vault" }
+
+# HTTP server
+axum = "0.8"
+hyper = { version = "1.6", features = ["server"] }
+http = "1.3"
+http-body-util = "0.1"
+
+# Async
+tokio.workspace = true
+
+# Error handling
+thiserror.workspace = true
+
+# Logging
+tracing.workspace = true
+
+# Utils
+chrono.workspace = true
+percent-encoding.workspace = true
+
+[dev-dependencies]
+axiomvault-crypto = { path = "../crypto" }
+axiomvault-storage = { path = "../storage" }
+serde_json.workspace = true
+tempfile.workspace = true
+reqwest = { workspace = true, features = ["json"] }

--- a/core/webdav/src/config.rs
+++ b/core/webdav/src/config.rs
@@ -1,0 +1,29 @@
+//! WebDAV server configuration.
+
+/// Configuration for the WebDAV server.
+#[derive(Debug, Clone)]
+pub struct WebDavConfig {
+    /// Address to bind to. Must be loopback only for security.
+    pub bind_address: String,
+    /// Port to listen on.
+    pub port: u16,
+    /// Maximum request body size in bytes (default: 256 MiB).
+    pub max_body_size: usize,
+}
+
+impl Default for WebDavConfig {
+    fn default() -> Self {
+        Self {
+            bind_address: "127.0.0.1".to_string(),
+            port: 8080,
+            max_body_size: 256 * 1024 * 1024, // 256 MiB
+        }
+    }
+}
+
+impl WebDavConfig {
+    /// Build a socket address string from bind_address and port.
+    pub fn socket_addr(&self) -> String {
+        format!("{}:{}", self.bind_address, self.port)
+    }
+}

--- a/core/webdav/src/handler.rs
+++ b/core/webdav/src/handler.rs
@@ -1,0 +1,484 @@
+//! WebDAV HTTP method handlers.
+//!
+//! Each handler translates a WebDAV method into vault operations via
+//! `VaultOperations`, performing decrypt-on-read and encrypt-on-write
+//! transparently.
+
+use std::sync::Arc;
+
+use axum::body::Body;
+use axum::extract::State;
+use axum::http::StatusCode;
+use axum::response::{IntoResponse, Response};
+use http_body_util::BodyExt;
+use tracing::debug;
+
+use axiomvault_common::VaultPath;
+use axiomvault_vault::{VaultOperations, VaultSession};
+
+use crate::xml::{self, PropEntry};
+
+/// Shared application state passed to all handlers.
+#[derive(Clone)]
+pub struct AppState {
+    pub session: Arc<VaultSession>,
+    pub max_body_size: usize,
+}
+
+/// Top-level router: dispatches by HTTP method.
+pub async fn handle_request(
+    State(state): State<AppState>,
+    req: axum::extract::Request,
+) -> Response {
+    let method = req.method().clone();
+    let path = req.uri().path().to_string();
+    let depth = req
+        .headers()
+        .get("Depth")
+        .and_then(|v| v.to_str().ok())
+        .unwrap_or("1")
+        .to_string();
+
+    match method.as_str() {
+        "OPTIONS" => handle_options(),
+        "PROPFIND" => handle_propfind(&state, &depth, &path).await,
+        "GET" => handle_get(&state, &path).await,
+        "HEAD" => handle_head(&state, &path).await,
+        "PUT" => handle_put(&state, req, &path).await,
+        "MKCOL" => handle_mkcol(&state, &path).await,
+        "DELETE" => handle_delete(&state, &path).await,
+        "MOVE" | "COPY" | "LOCK" | "UNLOCK" => not_implemented(),
+        _ => (StatusCode::METHOD_NOT_ALLOWED, "Method not allowed").into_response(),
+    }
+}
+
+/// OPTIONS — return allowed methods and DAV compliance headers.
+fn handle_options() -> Response {
+    Response::builder()
+        .status(StatusCode::OK)
+        .header("Allow", "OPTIONS, PROPFIND, GET, HEAD, PUT, MKCOL, DELETE")
+        .header("DAV", "1")
+        .header("Content-Length", "0")
+        .body(Body::empty())
+        .unwrap()
+}
+
+/// 501 Not Implemented for unsupported methods.
+fn not_implemented() -> Response {
+    (StatusCode::NOT_IMPLEMENTED, "Not implemented").into_response()
+}
+
+/// PROPFIND — list directory or return metadata for a single resource.
+async fn handle_propfind(state: &AppState, depth: &str, path: &str) -> Response {
+    debug!("PROPFIND request");
+
+    // Clamp "infinity" to "1" to avoid recursive listing
+    let depth = if depth == "infinity" { "1" } else { depth };
+
+    let vault_path = match normalize_vault_path(path) {
+        Ok(p) => p,
+        Err(status) => return error_response(status, "Invalid path"),
+    };
+
+    let ops = match VaultOperations::new(&state.session) {
+        Ok(ops) => ops,
+        Err(e) => return error_response(StatusCode::INTERNAL_SERVER_ERROR, &e.to_string()),
+    };
+
+    let mut entries = Vec::new();
+
+    // Get metadata for the requested path itself
+    match ops.metadata(&vault_path).await {
+        Ok((name, is_dir, size)) => {
+            let tree = state.session.tree().read().await;
+            let node = tree.get_node(&vault_path).ok();
+            let (created, modified, etag) = node
+                .map(|n| {
+                    (
+                        n.metadata.created_at,
+                        n.metadata.modified_at,
+                        n.metadata.etag.clone(),
+                    )
+                })
+                .unwrap_or_else(|| (chrono::Utc::now(), chrono::Utc::now(), None));
+            drop(tree);
+
+            let href = if is_dir {
+                ensure_trailing_slash(path)
+            } else {
+                path.to_string()
+            };
+
+            entries.push(PropEntry {
+                href,
+                display_name: if vault_path.is_root() {
+                    "/".to_string()
+                } else {
+                    name
+                },
+                is_collection: is_dir,
+                content_length: if is_dir { None } else { size },
+                content_type: if is_dir {
+                    "httpd/unix-directory".to_string()
+                } else {
+                    guess_mime(path)
+                },
+                last_modified: modified,
+                created,
+                etag,
+            });
+
+            // If depth=1 and this is a directory, list children
+            if depth == "1" && is_dir {
+                if let Ok(children) = ops.list_directory(&vault_path).await {
+                    let tree = state.session.tree().read().await;
+                    for (child_name, child_is_dir, child_size) in &children {
+                        let child_path_str = if vault_path.is_root() {
+                            format!("/{}", child_name)
+                        } else {
+                            format!("{}/{}", path.trim_end_matches('/'), child_name)
+                        };
+
+                        let child_vault_path = match VaultPath::parse(&child_path_str) {
+                            Ok(p) => p,
+                            Err(_) => continue,
+                        };
+
+                        let (child_created, child_modified, child_etag) = tree
+                            .get_node(&child_vault_path)
+                            .map(|n| {
+                                (
+                                    n.metadata.created_at,
+                                    n.metadata.modified_at,
+                                    n.metadata.etag.clone(),
+                                )
+                            })
+                            .unwrap_or_else(|_| (chrono::Utc::now(), chrono::Utc::now(), None));
+
+                        let child_href = if *child_is_dir {
+                            ensure_trailing_slash(&child_path_str)
+                        } else {
+                            child_path_str.clone()
+                        };
+
+                        entries.push(PropEntry {
+                            href: child_href,
+                            display_name: child_name.clone(),
+                            is_collection: *child_is_dir,
+                            content_length: if *child_is_dir { None } else { *child_size },
+                            content_type: if *child_is_dir {
+                                "httpd/unix-directory".to_string()
+                            } else {
+                                guess_mime(&child_path_str)
+                            },
+                            last_modified: child_modified,
+                            created: child_created,
+                            etag: child_etag,
+                        });
+                    }
+                }
+            }
+        }
+        Err(_) => {
+            return error_response(StatusCode::NOT_FOUND, "Resource not found");
+        }
+    }
+
+    let body = xml::build_multistatus(&entries);
+
+    Response::builder()
+        .status(StatusCode::MULTI_STATUS)
+        .header("Content-Type", "application/xml; charset=utf-8")
+        .body(Body::from(body))
+        .unwrap()
+}
+
+/// GET — read and decrypt file content.
+async fn handle_get(state: &AppState, path: &str) -> Response {
+    debug!("GET request");
+
+    let vault_path = match normalize_vault_path(path) {
+        Ok(p) => p,
+        Err(status) => return error_response(status, "Invalid path"),
+    };
+
+    let ops = match VaultOperations::new(&state.session) {
+        Ok(ops) => ops,
+        Err(e) => return error_response(StatusCode::INTERNAL_SERVER_ERROR, &e.to_string()),
+    };
+
+    // Check if it's a directory — can't GET a directory
+    match ops.metadata(&vault_path).await {
+        Ok((_, true, _)) => {
+            return error_response(StatusCode::METHOD_NOT_ALLOWED, "Cannot GET a directory");
+        }
+        Err(_) => return error_response(StatusCode::NOT_FOUND, "File not found"),
+        _ => {}
+    }
+
+    match ops.read_file(&vault_path).await {
+        Ok(content) => {
+            let mut builder = Response::builder()
+                .status(StatusCode::OK)
+                .header("Content-Type", guess_mime(path))
+                .header("Content-Length", content.len().to_string());
+
+            // Add Last-Modified and ETag from tree metadata
+            let tree = state.session.tree().read().await;
+            if let Ok(node) = tree.get_node(&vault_path) {
+                let modified = node
+                    .metadata
+                    .modified_at
+                    .format("%a, %d %b %Y %H:%M:%S GMT")
+                    .to_string();
+                builder = builder.header("Last-Modified", modified);
+                if let Some(ref etag) = node.metadata.etag {
+                    builder = builder.header("ETag", format!("\"{}\"", etag));
+                }
+            }
+
+            builder.body(Body::from(content)).unwrap()
+        }
+        Err(e) => error_response(StatusCode::INTERNAL_SERVER_ERROR, &e.to_string()),
+    }
+}
+
+/// HEAD — return metadata headers without body.
+async fn handle_head(state: &AppState, path: &str) -> Response {
+    debug!("HEAD request");
+
+    let vault_path = match normalize_vault_path(path) {
+        Ok(p) => p,
+        Err(status) => return error_response(status, "Invalid path"),
+    };
+
+    let ops = match VaultOperations::new(&state.session) {
+        Ok(ops) => ops,
+        Err(e) => return error_response(StatusCode::INTERNAL_SERVER_ERROR, &e.to_string()),
+    };
+
+    match ops.metadata(&vault_path).await {
+        Ok((_, is_dir, size)) => {
+            let mut builder = Response::builder().status(StatusCode::OK);
+
+            if is_dir {
+                builder = builder.header("Content-Type", "httpd/unix-directory");
+            } else {
+                builder = builder.header("Content-Type", guess_mime(path));
+                if let Some(s) = size {
+                    builder = builder.header("Content-Length", s.to_string());
+                }
+            }
+
+            let tree = state.session.tree().read().await;
+            if let Ok(node) = tree.get_node(&vault_path) {
+                let modified = node
+                    .metadata
+                    .modified_at
+                    .format("%a, %d %b %Y %H:%M:%S GMT")
+                    .to_string();
+                builder = builder.header("Last-Modified", modified);
+                if let Some(ref etag) = node.metadata.etag {
+                    builder = builder.header("ETag", format!("\"{}\"", etag));
+                }
+            }
+
+            builder.body(Body::empty()).unwrap()
+        }
+        Err(_) => error_response(StatusCode::NOT_FOUND, "Not found"),
+    }
+}
+
+/// PUT — create or update a file with encrypted content.
+async fn handle_put(state: &AppState, req: axum::extract::Request, path: &str) -> Response {
+    debug!("PUT request");
+
+    let vault_path = match normalize_vault_path(path) {
+        Ok(p) => p,
+        Err(status) => return error_response(status, "Invalid path"),
+    };
+
+    // Read request body with size limit
+    let body = match req.into_body().collect().await {
+        Ok(collected) => collected.to_bytes(),
+        Err(e) => return error_response(StatusCode::BAD_REQUEST, &e.to_string()),
+    };
+
+    if body.len() > state.max_body_size {
+        return error_response(
+            StatusCode::PAYLOAD_TOO_LARGE,
+            "Request body exceeds maximum size",
+        );
+    }
+
+    let ops = match VaultOperations::new(&state.session) {
+        Ok(ops) => ops,
+        Err(e) => return error_response(StatusCode::INTERNAL_SERVER_ERROR, &e.to_string()),
+    };
+
+    let exists = ops.exists(&vault_path).await;
+
+    if exists {
+        match ops.update_file(&vault_path, &body).await {
+            Ok(()) => StatusCode::NO_CONTENT.into_response(),
+            Err(e) => error_response(StatusCode::INTERNAL_SERVER_ERROR, &e.to_string()),
+        }
+    } else {
+        match ops.create_file(&vault_path, &body).await {
+            Ok(()) => StatusCode::CREATED.into_response(),
+            Err(e) => error_response(StatusCode::INTERNAL_SERVER_ERROR, &e.to_string()),
+        }
+    }
+}
+
+/// MKCOL — create a directory.
+async fn handle_mkcol(state: &AppState, path: &str) -> Response {
+    debug!("MKCOL request");
+
+    let vault_path = match normalize_vault_path(path) {
+        Ok(p) => p,
+        Err(status) => return error_response(status, "Invalid path"),
+    };
+
+    let ops = match VaultOperations::new(&state.session) {
+        Ok(ops) => ops,
+        Err(e) => return error_response(StatusCode::INTERNAL_SERVER_ERROR, &e.to_string()),
+    };
+
+    match ops.create_directory(&vault_path).await {
+        Ok(()) => StatusCode::CREATED.into_response(),
+        Err(e) => {
+            let msg = e.to_string();
+            if msg.contains("Already exists") {
+                error_response(StatusCode::METHOD_NOT_ALLOWED, "Directory already exists")
+            } else if msg.contains("Not found") {
+                error_response(StatusCode::CONFLICT, "Parent directory does not exist")
+            } else {
+                error_response(StatusCode::INTERNAL_SERVER_ERROR, &msg)
+            }
+        }
+    }
+}
+
+/// DELETE — remove a file or empty directory.
+async fn handle_delete(state: &AppState, path: &str) -> Response {
+    debug!("DELETE request");
+
+    let vault_path = match normalize_vault_path(path) {
+        Ok(p) => p,
+        Err(status) => return error_response(status, "Invalid path"),
+    };
+
+    let ops = match VaultOperations::new(&state.session) {
+        Ok(ops) => ops,
+        Err(e) => return error_response(StatusCode::INTERNAL_SERVER_ERROR, &e.to_string()),
+    };
+
+    // Check if it's a file or directory
+    match ops.metadata(&vault_path).await {
+        Ok((_, true, _)) => match ops.delete_directory(&vault_path).await {
+            Ok(()) => StatusCode::NO_CONTENT.into_response(),
+            Err(e) => error_response(StatusCode::INTERNAL_SERVER_ERROR, &e.to_string()),
+        },
+        Ok((_, false, _)) => match ops.delete_file(&vault_path).await {
+            Ok(()) => StatusCode::NO_CONTENT.into_response(),
+            Err(e) => error_response(StatusCode::INTERNAL_SERVER_ERROR, &e.to_string()),
+        },
+        Err(_) => error_response(StatusCode::NOT_FOUND, "Resource not found"),
+    }
+}
+
+/// Convert a URL path to a VaultPath, handling percent-decoding and normalization.
+fn normalize_vault_path(path: &str) -> Result<VaultPath, StatusCode> {
+    let decoded = percent_encoding::percent_decode_str(path)
+        .decode_utf8()
+        .map_err(|_| StatusCode::BAD_REQUEST)?;
+
+    let cleaned = decoded.trim_end_matches('/');
+    let normalized = if cleaned.is_empty() { "/" } else { cleaned };
+
+    VaultPath::parse(normalized).map_err(|_| StatusCode::BAD_REQUEST)
+}
+
+/// Ensure a path ends with `/` for collection hrefs.
+fn ensure_trailing_slash(path: &str) -> String {
+    if path.ends_with('/') {
+        path.to_string()
+    } else {
+        format!("{}/", path)
+    }
+}
+
+/// Simple MIME type guessing based on file extension.
+fn guess_mime(path: &str) -> String {
+    let ext = path.rsplit('.').next().unwrap_or("").to_ascii_lowercase();
+
+    match ext.as_str() {
+        "txt" | "text" => "text/plain",
+        "html" | "htm" => "text/html",
+        "css" => "text/css",
+        "js" => "application/javascript",
+        "json" => "application/json",
+        "xml" => "application/xml",
+        "pdf" => "application/pdf",
+        "zip" => "application/zip",
+        "gz" | "gzip" => "application/gzip",
+        "tar" => "application/x-tar",
+        "png" => "image/png",
+        "jpg" | "jpeg" => "image/jpeg",
+        "gif" => "image/gif",
+        "svg" => "image/svg+xml",
+        "webp" => "image/webp",
+        "mp3" => "audio/mpeg",
+        "mp4" => "video/mp4",
+        "webm" => "video/webm",
+        "wasm" => "application/wasm",
+        "md" => "text/markdown",
+        "csv" => "text/csv",
+        "yaml" | "yml" => "text/yaml",
+        "toml" => "application/toml",
+        "rs" => "text/x-rust",
+        "py" => "text/x-python",
+        "sh" => "text/x-shellscript",
+        "doc" | "docx" => "application/msword",
+        "xls" | "xlsx" => "application/vnd.ms-excel",
+        _ => "application/octet-stream",
+    }
+    .to_string()
+}
+
+/// Build an error response with a text body.
+fn error_response(status: StatusCode, message: &str) -> Response {
+    (status, message.to_string()).into_response()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_guess_mime() {
+        assert_eq!(guess_mime("/test.txt"), "text/plain");
+        assert_eq!(guess_mime("/test.png"), "image/png");
+        assert_eq!(guess_mime("/test.unknown"), "application/octet-stream");
+        assert_eq!(guess_mime("/no-extension"), "application/octet-stream");
+    }
+
+    #[test]
+    fn test_ensure_trailing_slash() {
+        assert_eq!(ensure_trailing_slash("/dir"), "/dir/");
+        assert_eq!(ensure_trailing_slash("/dir/"), "/dir/");
+    }
+
+    #[test]
+    fn test_normalize_vault_path() {
+        let p = normalize_vault_path("/test/file.txt").unwrap();
+        assert_eq!(p.to_string(), "/test/file.txt");
+
+        let p = normalize_vault_path("/").unwrap();
+        assert!(p.is_root());
+
+        let p = normalize_vault_path("/dir/").unwrap();
+        assert_eq!(p.to_string(), "/dir");
+    }
+}

--- a/core/webdav/src/lib.rs
+++ b/core/webdav/src/lib.rs
@@ -1,0 +1,383 @@
+//! WebDAV server for AxiomVault.
+//!
+//! Serves decrypted vault contents over a local loopback connection as a
+//! fallback when FUSE is unavailable. Files are transparently encrypted
+//! on write and decrypted on read.
+//!
+//! # Security
+//! - Binds only to `127.0.0.1` (never `0.0.0.0`)
+//! - No authentication layer (vault is already password-protected)
+//! - All operations go through `VaultOperations` which handles encryption
+
+pub mod config;
+pub mod handler;
+pub mod xml;
+
+use std::sync::Arc;
+
+use axum::Router;
+use tokio::net::TcpListener;
+use tracing::debug;
+
+use axiomvault_common::Result;
+use axiomvault_vault::VaultSession;
+
+pub use config::WebDavConfig;
+use handler::AppState;
+
+/// WebDAV server that exposes a vault over HTTP on the loopback interface.
+pub struct WebDavServer {
+    session: Arc<VaultSession>,
+    config: WebDavConfig,
+}
+
+impl WebDavServer {
+    /// Create a new WebDAV server.
+    pub fn new(session: Arc<VaultSession>, config: WebDavConfig) -> Self {
+        Self { session, config }
+    }
+
+    /// Start the server. Runs until the future is cancelled or the listener fails.
+    ///
+    /// This is designed to be spawned as a tokio task or selected alongside
+    /// a shutdown signal.
+    pub async fn start(&self) -> Result<()> {
+        let state = AppState {
+            session: self.session.clone(),
+            max_body_size: self.config.max_body_size,
+        };
+
+        let app = Router::new()
+            .fallback(handler::handle_request)
+            .with_state(state);
+
+        let addr = self.config.socket_addr();
+        debug!("Binding WebDAV server");
+
+        let listener = TcpListener::bind(&addr).await?;
+
+        axum::serve(listener, app).await.map_err(|e| {
+            axiomvault_common::Error::Io(std::io::Error::other(format!(
+                "WebDAV server error: {}",
+                e
+            )))
+        })
+    }
+
+    /// Return the URL the server will listen on (before starting).
+    pub fn url(&self) -> String {
+        format!("http://{}", self.config.socket_addr())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use axiomvault_common::VaultId;
+    use axiomvault_crypto::KdfParams;
+    use axiomvault_storage::{MemoryProvider, StorageProvider};
+    use axiomvault_vault::{VaultConfig, VaultOperations, VaultTree};
+    use http::Method;
+
+    /// Helper to create a test session with an in-memory storage provider.
+    async fn create_test_session() -> Arc<VaultSession> {
+        let id = VaultId::new("test").unwrap();
+        let password = b"test-password";
+        let params = KdfParams::moderate();
+        let creation =
+            VaultConfig::new(id, password, "memory", serde_json::Value::Null, params).unwrap();
+
+        let provider = Arc::new(MemoryProvider::new());
+
+        provider
+            .create_dir(&axiomvault_common::VaultPath::parse("/d").unwrap())
+            .await
+            .unwrap();
+
+        provider
+            .create_dir(&axiomvault_common::VaultPath::parse("/m").unwrap())
+            .await
+            .unwrap();
+
+        let session =
+            VaultSession::unlock(creation.config, password, provider, VaultTree::new()).unwrap();
+        Arc::new(session)
+    }
+
+    /// Find a free port for testing.
+    async fn free_port() -> u16 {
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        listener.local_addr().unwrap().port()
+    }
+
+    /// Start a WebDAV server in the background and return its base URL.
+    async fn start_test_server(session: Arc<VaultSession>) -> String {
+        let port = free_port().await;
+        let config = WebDavConfig {
+            bind_address: "127.0.0.1".to_string(),
+            port,
+            ..Default::default()
+        };
+        let server = WebDavServer::new(session, config);
+        let url = server.url();
+        tokio::spawn(async move {
+            let _ = server.start().await;
+        });
+        // Give the server a moment to bind
+        tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+        url
+    }
+
+    #[tokio::test]
+    async fn test_propfind_root() {
+        let session = create_test_session().await;
+
+        // Create a file so root is non-empty
+        let ops = VaultOperations::new(&session).unwrap();
+        ops.create_file(
+            &axiomvault_common::VaultPath::parse("/hello.txt").unwrap(),
+            b"Hello WebDAV",
+        )
+        .await
+        .unwrap();
+
+        let base_url = start_test_server(session).await;
+
+        let client = reqwest::Client::new();
+        let resp = client
+            .request(Method::from_bytes(b"PROPFIND").unwrap(), &base_url)
+            .header("Depth", "1")
+            .send()
+            .await
+            .unwrap();
+
+        assert_eq!(resp.status(), 207);
+        let body = resp.text().await.unwrap();
+        assert!(body.contains("<D:multistatus"));
+        assert!(body.contains("hello.txt"));
+    }
+
+    #[tokio::test]
+    async fn test_get_file() {
+        let session = create_test_session().await;
+        let ops = VaultOperations::new(&session).unwrap();
+        ops.create_file(
+            &axiomvault_common::VaultPath::parse("/test.txt").unwrap(),
+            b"decrypted content",
+        )
+        .await
+        .unwrap();
+
+        let base_url = start_test_server(session).await;
+
+        let client = reqwest::Client::new();
+        let resp = client
+            .get(format!("{}/test.txt", base_url))
+            .send()
+            .await
+            .unwrap();
+
+        assert_eq!(resp.status(), 200);
+        let body = resp.bytes().await.unwrap();
+        assert_eq!(&body[..], b"decrypted content");
+    }
+
+    #[tokio::test]
+    async fn test_put_create_file() {
+        let session = create_test_session().await;
+        let base_url = start_test_server(session.clone()).await;
+
+        let client = reqwest::Client::new();
+
+        // PUT a new file
+        let resp = client
+            .put(format!("{}/newfile.txt", base_url))
+            .body("new content")
+            .send()
+            .await
+            .unwrap();
+
+        assert_eq!(resp.status(), 201);
+
+        // Verify we can read it back
+        let resp = client
+            .get(format!("{}/newfile.txt", base_url))
+            .send()
+            .await
+            .unwrap();
+
+        assert_eq!(resp.status(), 200);
+        assert_eq!(resp.bytes().await.unwrap().as_ref(), b"new content");
+    }
+
+    #[tokio::test]
+    async fn test_put_update_file() {
+        let session = create_test_session().await;
+
+        let ops = VaultOperations::new(&session).unwrap();
+        ops.create_file(
+            &axiomvault_common::VaultPath::parse("/existing.txt").unwrap(),
+            b"old content",
+        )
+        .await
+        .unwrap();
+
+        let base_url = start_test_server(session).await;
+
+        let client = reqwest::Client::new();
+        let resp = client
+            .put(format!("{}/existing.txt", base_url))
+            .body("updated content")
+            .send()
+            .await
+            .unwrap();
+
+        assert_eq!(resp.status(), 204);
+
+        let resp = client
+            .get(format!("{}/existing.txt", base_url))
+            .send()
+            .await
+            .unwrap();
+
+        assert_eq!(resp.status(), 200);
+        assert_eq!(resp.bytes().await.unwrap().as_ref(), b"updated content");
+    }
+
+    #[tokio::test]
+    async fn test_delete_file() {
+        let session = create_test_session().await;
+        let ops = VaultOperations::new(&session).unwrap();
+        ops.create_file(
+            &axiomvault_common::VaultPath::parse("/todelete.txt").unwrap(),
+            b"delete me",
+        )
+        .await
+        .unwrap();
+
+        let base_url = start_test_server(session).await;
+
+        let client = reqwest::Client::new();
+        let resp = client
+            .delete(format!("{}/todelete.txt", base_url))
+            .send()
+            .await
+            .unwrap();
+
+        assert_eq!(resp.status(), 204);
+
+        // Verify it's gone
+        let resp = client
+            .get(format!("{}/todelete.txt", base_url))
+            .send()
+            .await
+            .unwrap();
+
+        assert_eq!(resp.status(), 404);
+    }
+
+    #[tokio::test]
+    async fn test_mkcol_create_directory() {
+        let session = create_test_session().await;
+        let base_url = start_test_server(session).await;
+
+        let client = reqwest::Client::new();
+        let resp = client
+            .request(
+                Method::from_bytes(b"MKCOL").unwrap(),
+                format!("{}/newdir", base_url),
+            )
+            .send()
+            .await
+            .unwrap();
+
+        assert_eq!(resp.status(), 201);
+
+        // Verify directory exists via PROPFIND
+        let resp = client
+            .request(
+                Method::from_bytes(b"PROPFIND").unwrap(),
+                format!("{}/newdir", base_url),
+            )
+            .header("Depth", "0")
+            .send()
+            .await
+            .unwrap();
+
+        assert_eq!(resp.status(), 207);
+        let body = resp.text().await.unwrap();
+        assert!(body.contains("<D:collection/>"));
+    }
+
+    #[tokio::test]
+    async fn test_options() {
+        let session = create_test_session().await;
+        let base_url = start_test_server(session).await;
+
+        let client = reqwest::Client::new();
+        let resp = client
+            .request(Method::OPTIONS, &base_url)
+            .send()
+            .await
+            .unwrap();
+
+        assert_eq!(resp.status(), 200);
+        let allow = resp.headers().get("allow").unwrap().to_str().unwrap();
+        assert!(allow.contains("PROPFIND"));
+        assert!(allow.contains("GET"));
+        assert!(allow.contains("PUT"));
+        let dav = resp.headers().get("dav").unwrap().to_str().unwrap();
+        assert_eq!(dav, "1");
+    }
+
+    #[tokio::test]
+    async fn test_unsupported_methods_return_501() {
+        let session = create_test_session().await;
+        let base_url = start_test_server(session).await;
+
+        let client = reqwest::Client::new();
+
+        for method_name in &["MOVE", "COPY", "LOCK", "UNLOCK"] {
+            let resp = client
+                .request(
+                    Method::from_bytes(method_name.as_bytes()).unwrap(),
+                    format!("{}/test", base_url),
+                )
+                .send()
+                .await
+                .unwrap();
+
+            assert_eq!(resp.status(), 501, "{} should return 501", method_name,);
+        }
+    }
+
+    #[tokio::test]
+    async fn test_head_file() {
+        let session = create_test_session().await;
+        let ops = VaultOperations::new(&session).unwrap();
+        ops.create_file(
+            &axiomvault_common::VaultPath::parse("/headtest.txt").unwrap(),
+            b"head content",
+        )
+        .await
+        .unwrap();
+
+        let base_url = start_test_server(session).await;
+
+        let client = reqwest::Client::new();
+        let resp = client
+            .head(format!("{}/headtest.txt", base_url))
+            .send()
+            .await
+            .unwrap();
+
+        assert_eq!(resp.status(), 200);
+        let ct = resp
+            .headers()
+            .get("content-type")
+            .unwrap()
+            .to_str()
+            .unwrap();
+        assert_eq!(ct, "text/plain");
+    }
+}

--- a/core/webdav/src/xml.rs
+++ b/core/webdav/src/xml.rs
@@ -1,0 +1,158 @@
+//! WebDAV XML response generation.
+//!
+//! Generates RFC 4918 compliant XML for PROPFIND multi-status responses.
+//! Uses string formatting instead of a heavy XML crate since WebDAV XML
+//! is structurally simple.
+
+use chrono::{DateTime, Utc};
+
+/// A single resource entry for a PROPFIND response.
+pub struct PropEntry {
+    /// URL-encoded href path (e.g. `/path/to/file.txt`).
+    pub href: String,
+    /// Display name of the resource.
+    pub display_name: String,
+    /// Whether this is a collection (directory).
+    pub is_collection: bool,
+    /// Content length in bytes (files only).
+    pub content_length: Option<u64>,
+    /// MIME content type.
+    pub content_type: String,
+    /// Last modification time.
+    pub last_modified: DateTime<Utc>,
+    /// Creation time.
+    pub created: DateTime<Utc>,
+    /// ETag value (if available).
+    pub etag: Option<String>,
+}
+
+/// Build a complete `207 Multi-Status` XML body from a list of property entries.
+pub fn build_multistatus(entries: &[PropEntry]) -> String {
+    let mut xml = String::with_capacity(1024);
+    xml.push_str("<?xml version=\"1.0\" encoding=\"utf-8\"?>\n");
+    xml.push_str("<D:multistatus xmlns:D=\"DAV:\">\n");
+
+    for entry in entries {
+        xml.push_str("  <D:response>\n");
+        xml.push_str("    <D:href>");
+        xml.push_str(&xml_escape(&entry.href));
+        xml.push_str("</D:href>\n");
+        xml.push_str("    <D:propstat>\n");
+        xml.push_str("      <D:prop>\n");
+
+        // displayname
+        xml.push_str("        <D:displayname>");
+        xml.push_str(&xml_escape(&entry.display_name));
+        xml.push_str("</D:displayname>\n");
+
+        // resourcetype
+        if entry.is_collection {
+            xml.push_str("        <D:resourcetype><D:collection/></D:resourcetype>\n");
+        } else {
+            xml.push_str("        <D:resourcetype/>\n");
+        }
+
+        // getcontentlength (files only)
+        if let Some(len) = entry.content_length {
+            xml.push_str("        <D:getcontentlength>");
+            xml.push_str(&len.to_string());
+            xml.push_str("</D:getcontentlength>\n");
+        }
+
+        // getcontenttype
+        xml.push_str("        <D:getcontenttype>");
+        xml.push_str(&xml_escape(&entry.content_type));
+        xml.push_str("</D:getcontenttype>\n");
+
+        // getlastmodified (RFC 2822)
+        xml.push_str("        <D:getlastmodified>");
+        xml.push_str(
+            &entry
+                .last_modified
+                .format("%a, %d %b %Y %H:%M:%S GMT")
+                .to_string(),
+        );
+        xml.push_str("</D:getlastmodified>\n");
+
+        // creationdate (ISO 8601)
+        xml.push_str("        <D:creationdate>");
+        xml.push_str(&entry.created.to_rfc3339());
+        xml.push_str("</D:creationdate>\n");
+
+        // getetag
+        if let Some(ref etag) = entry.etag {
+            xml.push_str("        <D:getetag>\"");
+            xml.push_str(&xml_escape(etag));
+            xml.push_str("\"</D:getetag>\n");
+        }
+
+        xml.push_str("      </D:prop>\n");
+        xml.push_str("      <D:status>HTTP/1.1 200 OK</D:status>\n");
+        xml.push_str("    </D:propstat>\n");
+        xml.push_str("  </D:response>\n");
+    }
+
+    xml.push_str("</D:multistatus>\n");
+    xml
+}
+
+/// Escape special XML characters.
+fn xml_escape(s: &str) -> String {
+    s.replace('&', "&amp;")
+        .replace('<', "&lt;")
+        .replace('>', "&gt;")
+        .replace('"', "&quot;")
+        .replace('\'', "&apos;")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_xml_escape() {
+        assert_eq!(xml_escape("<test>&\"'"), "&lt;test&gt;&amp;&quot;&apos;");
+    }
+
+    #[test]
+    fn test_build_multistatus_file() {
+        let now = Utc::now();
+        let entries = vec![PropEntry {
+            href: "/test.txt".to_string(),
+            display_name: "test.txt".to_string(),
+            is_collection: false,
+            content_length: Some(42),
+            content_type: "text/plain".to_string(),
+            last_modified: now,
+            created: now,
+            etag: Some("abc123".to_string()),
+        }];
+
+        let xml = build_multistatus(&entries);
+        assert!(xml.contains("<D:multistatus"));
+        assert!(xml.contains("<D:href>/test.txt</D:href>"));
+        assert!(xml.contains("<D:getcontentlength>42</D:getcontentlength>"));
+        assert!(xml.contains("<D:resourcetype/>"));
+        assert!(xml.contains("<D:getetag>\"abc123\"</D:getetag>"));
+    }
+
+    #[test]
+    fn test_build_multistatus_collection() {
+        let now = Utc::now();
+        let entries = vec![PropEntry {
+            href: "/docs/".to_string(),
+            display_name: "docs".to_string(),
+            is_collection: true,
+            content_length: None,
+            content_type: "httpd/unix-directory".to_string(),
+            last_modified: now,
+            created: now,
+            etag: None,
+        }];
+
+        let xml = build_multistatus(&entries);
+        assert!(xml.contains("<D:collection/>"));
+        assert!(!xml.contains("<D:getcontentlength>"));
+        assert!(!xml.contains("<D:getetag>"));
+    }
+}

--- a/tools/cli/Cargo.toml
+++ b/tools/cli/Cargo.toml
@@ -14,6 +14,7 @@ axiomvault-crypto = { path = "../../core/crypto" }
 axiomvault-storage = { path = "../../core/storage" }
 axiomvault-vault = { path = "../../core/vault" }
 axiomvault-sync = { path = "../../core/sync" }
+axiomvault-webdav = { path = "../../core/webdav" }
 
 serde.workspace = true
 clap.workspace = true

--- a/tools/cli/src/main.rs
+++ b/tools/cli/src/main.rs
@@ -416,6 +416,17 @@ enum Commands {
         target: Option<usize>,
     },
 
+    /// Serve vault contents over WebDAV on the loopback interface.
+    Webdav {
+        /// Path to the vault.
+        #[arg(short, long)]
+        path: PathBuf,
+
+        /// Port to listen on (default: 8080).
+        #[arg(long, default_value_t = 8080)]
+        port: u16,
+    },
+
     /// Configure or change the RAID mode.
     RaidConfigure {
         /// Path to the vault.
@@ -565,6 +576,8 @@ async fn main() -> Result<()> {
             data_shards,
             parity_shards,
         } => cmd_raid_configure(&vault_path, mode, data_shards, parity_shards).await,
+
+        Commands::Webdav { path, port } => cmd_webdav(&path, port).await,
     }
 }
 
@@ -2397,6 +2410,43 @@ async fn cmd_raid_configure(
     }
 
     Ok(())
+}
+
+/// Serve vault contents over WebDAV.
+async fn cmd_webdav(path: &Path, port: u16) -> Result<()> {
+    info!("Starting WebDAV server for vault at: {}", path.display());
+
+    let password = prompt_password("Enter password: ")?;
+    let vault_path = path.to_string_lossy().to_string();
+
+    let manager = VaultManager::new();
+    let provider_config = serde_json::json!({
+        "root": vault_path
+    });
+
+    let session = manager
+        .open_vault("local", provider_config, &password)
+        .await
+        .context("Failed to open vault")?;
+
+    let session = Arc::new(session);
+
+    let config = axiomvault_webdav::WebDavConfig {
+        bind_address: "127.0.0.1".to_string(),
+        port,
+        ..Default::default()
+    };
+
+    let server = axiomvault_webdav::WebDavServer::new(session, config);
+    let url = server.url();
+
+    println!("WebDAV server running at {}/", url);
+    println!("Press Ctrl+C to stop.");
+
+    server
+        .start()
+        .await
+        .map_err(|e| anyhow::anyhow!("WebDAV server error: {}", e))
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## Summary

New `core/webdav` crate implementing an embedded WebDAV server for vault access when FUSE is unavailable.

### WebDAV Methods
| Method | Status | Description |
|--------|--------|-------------|
| OPTIONS | 200 | Returns allowed methods + DAV:1 compliance |
| PROPFIND | 207 | Directory listings with full metadata (size, timestamps, etag) |
| GET | 200 | Decrypt-on-read file access with Content-Type, ETag, Last-Modified |
| HEAD | 200 | Metadata headers without body |
| PUT | 201/204 | Encrypt-on-write file creation/update (256 MiB limit) |
| MKCOL | 201 | Create directories |
| DELETE | 204 | Remove files and empty directories |
| MOVE/COPY/LOCK | 501 | Not implemented (future work) |

### Architecture
- Binds to `127.0.0.1` only (security: local access only)
- Uses `axum` for HTTP routing, translates to vault operations via `VaultSession`
- XML responses generated without heavy XML dependencies
- All file operations are transparent encrypt/decrypt

### CLI Integration
```bash
axiomvault webdav --path <vault-dir> [--port 8080]
```
Opens vault, starts WebDAV server, prints URL, waits for Ctrl+C.

### Files
- `core/webdav/` — New crate (1,089 lines: handlers, XML builder, config, tests)
- `tools/cli/src/main.rs` — `webdav` subcommand added
- `Cargo.toml` — Workspace member added

Closes #61.

## Test plan

- [x] 15 new tests (PROPFIND, GET, PUT, DELETE, MKCOL, HEAD, OPTIONS, 501s, XML, MIME)
- [x] All 383 workspace tests pass
- [x] `cargo clippy --workspace --all-features -- -D warnings` clean
- [x] `cargo doc` clean
- [ ] CI pipeline
- [ ] CodeRabbit review

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>