### PR TITLE
security: close 12 findings from 2026-04-21 audit

### DIFF
--- a/.githooks/check-unsafe.sh
+++ b/.githooks/check-unsafe.sh
@@ -6,7 +6,10 @@ exit_code=0
 for file in "$@"; do
     [ "${file##*.}" = "rs" ] || continue
 
-    # Get all lines with 'unsafe'
+    # Get all lines containing an `unsafe { ... }` block or an
+    # `unsafe impl|fn|trait` declaration. We match the block form anywhere on
+    # the line (catches inline expressions like `uid: unsafe { libc::getuid() }`)
+    # and the declaration form at the start of a line.
     while IFS= read -r line_num; do
         # Check 3 lines before and the current line for SAFETY comment
         start=$((line_num - 3))
@@ -19,7 +22,7 @@ for file in "$@"; do
             sed -n "$((line_num))p" "$file" | sed 's/^/    /'
             exit_code=1
         fi
-    done < <(grep -n "^\s*unsafe" "$file" | cut -d: -f1)
+    done < <(grep -nE 'unsafe[[:space:]]*\{|^[[:space:]]*(pub[[:space:]]+)?unsafe[[:space:]]+(impl|fn|trait|extern)' "$file" | cut -d: -f1)
 done
 
 if [ $exit_code -ne 0 ]; then

--- a/.githooks/check-unsafe.sh
+++ b/.githooks/check-unsafe.sh
@@ -10,6 +10,10 @@ for file in "$@"; do
     # `unsafe impl|fn|trait` declaration. We match the block form anywhere on
     # the line (catches inline expressions like `uid: unsafe { libc::getuid() }`)
     # and the declaration form at the start of a line.
+    #
+    # The optional visibility prefix accepts `pub`, `pub(crate)`, `pub(super)`,
+    # `pub(self)`, and `pub(in path::to::module)` so that a `pub(crate) unsafe
+    # fn foo()` is not silently exempt from the SAFETY comment requirement.
     while IFS= read -r line_num; do
         # Check 3 lines before and the current line for SAFETY comment
         start=$((line_num - 3))
@@ -22,7 +26,7 @@ for file in "$@"; do
             sed -n "$((line_num))p" "$file" | sed 's/^/    /'
             exit_code=1
         fi
-    done < <(grep -nE 'unsafe[[:space:]]*\{|^[[:space:]]*(pub[[:space:]]+)?unsafe[[:space:]]+(impl|fn|trait|extern)' "$file" | cut -d: -f1)
+    done < <(grep -nE 'unsafe[[:space:]]*\{|^[[:space:]]*(pub([[:space:]]*\([[:space:]]*(crate|super|self|in[[:space:]]+[^)]+)[[:space:]]*\))?[[:space:]]+)?unsafe[[:space:]]+(impl|fn|trait|extern)' "$file" | cut -d: -f1)
 done
 
 if [ $exit_code -ne 0 ]; then

--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,6 @@ clients/apple/Frameworks/
 clients/apple/build/
 clients/apple/**/*.xcuserstate
 clients/apple/AxiomVault.xcodeproj/project.pbxproj
+
+# Git worktrees
+.worktrees/

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -174,6 +174,7 @@ dependencies = [
  "tokio",
  "tracing",
  "tracing-subscriber",
+ "zeroize",
 ]
 
 [[package]]
@@ -288,6 +289,7 @@ dependencies = [
  "tokio",
  "tracing",
  "tracing-subscriber",
+ "zeroize",
 ]
 
 [[package]]

--- a/clients/apple/Shared/Sources/Core/AxiomVault-Bridging-Header.h
+++ b/clients/apple/Shared/Sources/Core/AxiomVault-Bridging-Header.h
@@ -80,9 +80,11 @@ int axiom_vault_change_password(const FFIVaultHandle *handle,
 
 // Returns recovery words from vault creation (one-time, cleared after call).
 // Returns NULL if vault was opened or words already consumed.
+// MUST be freed with axiom_recovery_words_free (NOT axiom_string_free).
 char *axiom_vault_get_recovery_words(const FFIVaultHandle *handle);
 
 // Returns the recovery key for an open vault (requires active session).
+// MUST be freed with axiom_recovery_words_free (NOT axiom_string_free).
 char *axiom_vault_show_recovery_key(const FFIVaultHandle *handle);
 
 // Reset password using recovery words. Returns a new vault handle on success.
@@ -118,5 +120,11 @@ int axiom_vault_subscribe_events(const FFIVaultHandle *handle,
 
 char *axiom_last_error(void);
 void axiom_string_free(char *s);
+
+// Zeroize-then-free for strings containing secrets (recovery mnemonics).
+// REQUIRED for buffers returned by axiom_vault_get_recovery_words and
+// axiom_vault_show_recovery_key. Using axiom_string_free on those buffers
+// leaks the credential bytes into freed heap memory.
+void axiom_recovery_words_free(char *s);
 
 #endif /* AxiomVault_Bridging_Header_h */

--- a/clients/apple/Shared/Sources/Core/VaultCore.swift
+++ b/clients/apple/Shared/Sources/Core/VaultCore.swift
@@ -217,11 +217,12 @@ class VaultCore {
         handle = newHandle
         subscribeEventsLocked()
 
-        // Retrieve recovery words (one-time).
+        // Retrieve recovery words (one-time). MUST use axiom_recovery_words_free
+        // so the source bytes are zeroized before the C buffer is released.
         var recoveryWords: String? = nil
         if let wordsPtr = axiom_vault_get_recovery_words(newHandle) {
             recoveryWords = String(cString: wordsPtr)
-            axiom_string_free(wordsPtr)
+            axiom_recovery_words_free(wordsPtr)
         }
 
         return recoveryWords
@@ -373,7 +374,8 @@ class VaultCore {
         guard let wordsPtr = axiom_vault_show_recovery_key(currentHandle) else {
             throw VaultError.operationFailed(getLastError())
         }
-        defer { axiom_string_free(wordsPtr) }
+        // Zeroize-then-free: recovery words are credentials.
+        defer { axiom_recovery_words_free(wordsPtr) }
 
         return String(cString: wordsPtr)
     }

--- a/clients/linux/Cargo.toml
+++ b/clients/linux/Cargo.toml
@@ -14,6 +14,9 @@ path = "src/main.rs"
 # Shared application facade — the only core dependency the UI shell needs.
 axiomvault-app = { path = "../../core/app" }
 
+# Wipe password buffers crossing the FFI/UI boundary into AppService.
+zeroize.workspace = true
+
 # GTK4 / libadwaita
 gtk = { package = "gtk4", version = "0.9", features = ["v4_12"] }
 adw = { package = "libadwaita", version = "0.7", features = ["v1_4"] }

--- a/clients/linux/src/ui/mod.rs
+++ b/clients/linux/src/ui/mod.rs
@@ -1,6 +1,7 @@
 //! UI module — GTK4/libadwaita views.
 
 mod browser;
+mod recovery_dialog;
 mod unlock;
 mod window;
 

--- a/clients/linux/src/ui/recovery_dialog.rs
+++ b/clients/linux/src/ui/recovery_dialog.rs
@@ -27,10 +27,6 @@ use zeroize::Zeroizing;
 /// Response id used when the user confirms they have saved the words. This is
 /// the only response that dismisses the dialog.
 const RESPONSE_CONFIRM: &str = "confirm";
-/// Response id for the "Copy to clipboard" action. It does not close the
-/// dialog so the user can still read the words after copying.
-const RESPONSE_COPY: &str = "copy";
-
 /// Build and present a modal recovery-words dialog.
 ///
 /// * `parent` — any widget inside the window the dialog should be transient
@@ -78,9 +74,20 @@ where
         .margin_end(12)
         .build();
 
-    dialog.set_extra_child(Some(&words_label));
+    let copy_button = gtk::Button::builder()
+        .label("Copy to Clipboard")
+        .halign(gtk::Align::Center)
+        .margin_bottom(12)
+        .build();
 
-    dialog.add_response(RESPONSE_COPY, "_Copy to Clipboard");
+    let content = gtk::Box::builder()
+        .orientation(gtk::Orientation::Vertical)
+        .spacing(12)
+        .build();
+    content.append(&words_label);
+    content.append(&copy_button);
+    dialog.set_extra_child(Some(&content));
+
     dialog.add_response(RESPONSE_CONFIRM, "I've _Saved My Recovery Words");
     dialog.set_response_appearance(RESPONSE_CONFIRM, adw::ResponseAppearance::Suggested);
     dialog.set_default_response(Some(RESPONSE_CONFIRM));
@@ -104,42 +111,44 @@ where
     // opening and dismissing the dialog.
     let we_wrote_clipboard = Rc::new(Cell::new(false));
 
+    let words_cell = Rc::new(words_cell);
+    let words_cell_for_copy = words_cell.clone();
+    let we_wrote_clipboard_for_copy = we_wrote_clipboard.clone();
+    copy_button.connect_clicked(move |_| {
+        if let Some(words) = words_cell_for_copy.borrow().as_deref() {
+            if let Some(display) = gdk::Display::default() {
+                display.clipboard().set_text(words);
+                we_wrote_clipboard_for_copy.set(true);
+            }
+        }
+    });
+
     let we_wrote_clipboard_handler = we_wrote_clipboard.clone();
-    dialog.connect_response(None, move |dlg, response| match response {
-        RESPONSE_COPY => {
-            if let Some(words) = words_cell.borrow().as_deref() {
-                if let Some(display) = gdk::Display::default() {
-                    display.clipboard().set_text(words);
-                    we_wrote_clipboard_handler.set(true);
-                }
+    dialog.connect_response(None, move |dlg, _response| {
+        // Any dialog response (confirm / close) dismisses the dialog. Copy is
+        // a normal button in `extra_child`, not an AdwMessageDialog response,
+        // because activating any response closes the dialog automatically.
+        // Drop the recovery words first so the wipe runs before we invoke the
+        // caller's completion handler.
+        drop(words_cell.borrow_mut().take());
+        // Threat model: the recovery words are equivalent to the master key.
+        // If we copied them to the clipboard, every other process on the
+        // system can read them via paste until something else is copied.
+        // Overwrite our own clipboard contents on dismiss to bound that
+        // window. We only wipe when *we* wrote (tracked above) so we don't
+        // clobber unrelated data the user copied in the interim.
+        if we_wrote_clipboard_handler.get() {
+            if let Some(display) = gdk::Display::default() {
+                display.clipboard().set_text("");
             }
-            // Keep the dialog open — the user still needs to confirm.
         }
-        _ => {
-            // Any other response (confirm / close) dismisses the dialog.
-            // Drop the recovery words first so the wipe runs before we
-            // invoke the caller's completion handler.
-            drop(words_cell.borrow_mut().take());
-            // Threat model: the recovery words are equivalent to the
-            // master key. If we copied them to the clipboard, every other
-            // process on the system can read them via paste until something
-            // else is copied. Overwrite our own clipboard contents on
-            // dismiss to bound that window. We only wipe when *we* wrote
-            // (tracked above) so we don't clobber unrelated data the user
-            // copied in the interim.
-            if we_wrote_clipboard_handler.get() {
-                if let Some(display) = gdk::Display::default() {
-                    display.clipboard().set_text("");
-                }
-            }
-            if let Some(cb) = on_dismissed.borrow_mut().take() {
-                // Run the callback asynchronously to ensure `present()`
-                // has fully unwound before the caller mutates any UI that
-                // might still be animating the dialog away.
-                glib::idle_add_local_once(cb);
-            }
-            dlg.close();
+        if let Some(cb) = on_dismissed.borrow_mut().take() {
+            // Run the callback asynchronously to ensure `present()` has fully
+            // unwound before the caller mutates any UI that might still be
+            // animating the dialog away.
+            glib::idle_add_local_once(cb);
         }
+        dlg.close();
     });
 
     dialog.present();

--- a/clients/linux/src/ui/recovery_dialog.rs
+++ b/clients/linux/src/ui/recovery_dialog.rs
@@ -1,0 +1,145 @@
+//! One-time recovery-words disclosure dialog.
+//!
+//! Displays the 24 BIP-39 recovery words in a modal dialog that the user must
+//! explicitly acknowledge before dismissing. The words never appear on any
+//! persistent widget (e.g. the unlock status label) so that:
+//!
+//! * They are not visible to anyone walking past the screen after vault
+//!   creation.
+//! * They are not read aloud by accessibility tools attached to the main
+//!   window.
+//! * They do not sit in screenshots or screen recordings of normal vault use.
+//!
+//! The words are held in a [`Zeroizing<String>`] that is dropped — and thus
+//! wiped — as soon as the dialog is closed.
+//!
+//! Implementation note: this crate targets libadwaita `v1_4`, so we use
+//! [`adw::MessageDialog`]. `adw::AlertDialog` (libadwaita 1.5) would be the
+//! newer idiom but is not available on this feature set.
+
+use adw::prelude::*;
+use gtk::{gdk, glib};
+use zeroize::Zeroizing;
+
+/// Response id used when the user confirms they have saved the words. This is
+/// the only response that dismisses the dialog.
+const RESPONSE_CONFIRM: &str = "confirm";
+/// Response id for the "Copy to clipboard" action. It does not close the
+/// dialog so the user can still read the words after copying.
+const RESPONSE_COPY: &str = "copy";
+
+/// Build and present a modal recovery-words dialog.
+///
+/// * `parent` — any widget inside the window the dialog should be transient
+///   for. The nearest [`gtk::Window`] ancestor is used.
+/// * `words` — the 24 recovery words. The value is consumed; its heap buffer
+///   is wiped when the dialog is dismissed.
+/// * `on_dismissed` — invoked on the GTK main thread after the dialog has
+///   been closed by the user.
+pub fn show_recovery_words_dialog<W, F>(parent: &W, words: Zeroizing<String>, on_dismissed: F)
+where
+    W: IsA<gtk::Widget>,
+    F: FnOnce() + 'static,
+{
+    let parent_window = parent
+        .root()
+        .and_then(|root| root.downcast::<gtk::Window>().ok());
+
+    let mut builder = adw::MessageDialog::builder()
+        .modal(true)
+        .heading("Save Your Recovery Words");
+    if let Some(win) = parent_window.as_ref() {
+        builder = builder.transient_for(win);
+    }
+    let dialog = builder
+        .body(
+            "These 24 words are the only way to recover your vault if you \
+             forget your password. Write them down and store them somewhere \
+             safe. They will not be shown again.",
+        )
+        .build();
+
+    // Read-only, selectable label so the user can copy any or all words
+    // manually. `selectable` + GTK's default behaviour means the widget is
+    // not editable.
+    let words_label = gtk::Label::builder()
+        .label(words.as_str())
+        .selectable(true)
+        .wrap(true)
+        .wrap_mode(gtk::pango::WrapMode::WordChar)
+        .justify(gtk::Justification::Center)
+        .css_classes(["monospace", "title-4"])
+        .margin_top(12)
+        .margin_bottom(12)
+        .margin_start(12)
+        .margin_end(12)
+        .build();
+
+    dialog.set_extra_child(Some(&words_label));
+
+    dialog.add_response(RESPONSE_COPY, "_Copy to Clipboard");
+    dialog.add_response(RESPONSE_CONFIRM, "I've _Saved My Recovery Words");
+    dialog.set_response_appearance(RESPONSE_CONFIRM, adw::ResponseAppearance::Suggested);
+    dialog.set_default_response(Some(RESPONSE_CONFIRM));
+    // Make the confirmation response the only way to dismiss the dialog —
+    // Escape / closing the window treats it as a confirm so we don't silently
+    // re-open the flow with stale state.
+    dialog.set_close_response(RESPONSE_CONFIRM);
+
+    // The dialog owns the `Zeroizing<String>` until it is closed. We move it
+    // into the response signal handler; `connect_response` is invoked at most
+    // once for the closing response, so the wrapper-side drop (and therefore
+    // the wipe) happens deterministically. `connect_response` takes an `Fn`
+    // closure, so interior mutability is required for both the words buffer
+    // and the one-shot completion callback.
+    let words_cell = std::cell::RefCell::new(Some(words));
+    let on_dismissed = std::cell::RefCell::new(Some(on_dismissed));
+
+    dialog.connect_response(None, move |dlg, response| match response {
+        RESPONSE_COPY => {
+            if let Some(words) = words_cell.borrow().as_deref() {
+                if let Some(display) = gdk::Display::default() {
+                    display.clipboard().set_text(words);
+                }
+            }
+            // Keep the dialog open — the user still needs to confirm.
+        }
+        _ => {
+            // Any other response (confirm / close) dismisses the dialog.
+            // Drop the recovery words first so the wipe runs before we
+            // invoke the caller's completion handler.
+            drop(words_cell.borrow_mut().take());
+            if let Some(cb) = on_dismissed.borrow_mut().take() {
+                // Run the callback asynchronously to ensure `present()`
+                // has fully unwound before the caller mutates any UI that
+                // might still be animating the dialog away.
+                glib::idle_add_local_once(cb);
+            }
+            dlg.close();
+        }
+    });
+
+    dialog.present();
+}
+
+#[cfg(test)]
+mod tests {
+    use super::show_recovery_words_dialog;
+    use zeroize::Zeroizing;
+
+    /// Compile-time assertion that the dialog entry point stays reachable
+    /// with the expected shape: `(parent: &impl IsA<Widget>,
+    /// words: Zeroizing<String>, on_dismissed: impl FnOnce() + 'static)`.
+    ///
+    /// A future refactor that deletes or renames the one-time disclosure
+    /// flow will break this symbol reference and fail the build — so the
+    /// recovery-words UI cannot silently revert to a persistent label.
+    #[test]
+    fn dialog_entry_point_is_reachable() {
+        // Monomorphise for a specific widget + callback type so the compiler
+        // actually resolves the generic function rather than leaving it
+        // unreferenced in a where-clause.
+        let _: fn(&gtk::Widget, Zeroizing<String>, fn()) =
+            show_recovery_words_dialog::<gtk::Widget, fn()>;
+    }
+}

--- a/clients/linux/src/ui/recovery_dialog.rs
+++ b/clients/linux/src/ui/recovery_dialog.rs
@@ -17,6 +17,9 @@
 //! [`adw::MessageDialog`]. `adw::AlertDialog` (libadwaita 1.5) would be the
 //! newer idiom but is not available on this feature set.
 
+use std::cell::Cell;
+use std::rc::Rc;
+
 use adw::prelude::*;
 use gtk::{gdk, glib};
 use zeroize::Zeroizing;
@@ -94,12 +97,20 @@ where
     // and the one-shot completion callback.
     let words_cell = std::cell::RefCell::new(Some(words));
     let on_dismissed = std::cell::RefCell::new(Some(on_dismissed));
+    // Tracks whether *we* wrote the recovery words to the system clipboard.
+    // Only set when the user clicks "Copy to Clipboard". On dismiss we use
+    // this to decide whether to wipe — we must not unconditionally clear,
+    // or we'd erase whatever the user copied (from elsewhere) between
+    // opening and dismissing the dialog.
+    let we_wrote_clipboard = Rc::new(Cell::new(false));
 
+    let we_wrote_clipboard_handler = we_wrote_clipboard.clone();
     dialog.connect_response(None, move |dlg, response| match response {
         RESPONSE_COPY => {
             if let Some(words) = words_cell.borrow().as_deref() {
                 if let Some(display) = gdk::Display::default() {
                     display.clipboard().set_text(words);
+                    we_wrote_clipboard_handler.set(true);
                 }
             }
             // Keep the dialog open — the user still needs to confirm.
@@ -109,6 +120,18 @@ where
             // Drop the recovery words first so the wipe runs before we
             // invoke the caller's completion handler.
             drop(words_cell.borrow_mut().take());
+            // Threat model: the recovery words are equivalent to the
+            // master key. If we copied them to the clipboard, every other
+            // process on the system can read them via paste until something
+            // else is copied. Overwrite our own clipboard contents on
+            // dismiss to bound that window. We only wipe when *we* wrote
+            // (tracked above) so we don't clobber unrelated data the user
+            // copied in the interim.
+            if we_wrote_clipboard_handler.get() {
+                if let Some(display) = gdk::Display::default() {
+                    display.clipboard().set_text("");
+                }
+            }
             if let Some(cb) = on_dismissed.borrow_mut().take() {
                 // Run the callback asynchronously to ensure `present()`
                 // has fully unwound before the caller mutates any UI that
@@ -141,5 +164,29 @@ mod tests {
         // unreferenced in a where-clause.
         let _: fn(&gtk::Widget, Zeroizing<String>, fn()) =
             show_recovery_words_dialog::<gtk::Widget, fn()>;
+    }
+
+    /// Guard the clipboard-wipe-on-dismiss branch against silent removal.
+    ///
+    /// We can't drive a real GTK dismissal without a display server in CI,
+    /// so we assert structurally on the source: both the gating flag set
+    /// in the copy branch and the clearing `set_text("")` call in the
+    /// dismiss branch must be present. A future "simplification" that
+    /// drops the wipe will fail this test instead of silently leaving the
+    /// recovery words in the system clipboard.
+    #[test]
+    fn dismiss_branch_clears_clipboard_when_we_wrote_it() {
+        let src = include_str!("recovery_dialog.rs");
+        assert!(
+            src.contains("we_wrote_clipboard_handler.set(true)"),
+            "copy branch must mark that we wrote to the clipboard so the \
+             dismiss branch can wipe only what we put there"
+        );
+        assert!(
+            src.contains("display.clipboard().set_text(\"\")"),
+            "dismiss branch must overwrite our own clipboard contents — \
+             the recovery words are master-key equivalent and must not \
+             linger after the dialog closes"
+        );
     }
 }

--- a/clients/linux/src/ui/unlock.rs
+++ b/clients/linux/src/ui/unlock.rs
@@ -8,6 +8,7 @@ use adw::prelude::*;
 use axiomvault_app::OpenVaultParams;
 
 use crate::app::{self, AppState};
+use crate::ui::recovery_dialog::show_recovery_words_dialog;
 
 /// The initial view: enter a vault path and password to unlock.
 pub struct UnlockView {
@@ -134,6 +135,7 @@ impl UnlockView {
 
                 status_label.set_text("Creating vault...");
                 let status = status_label.clone();
+                let parent = status_label.clone();
                 let st = state.borrow();
 
                 app::spawn_async(
@@ -150,10 +152,12 @@ impl UnlockView {
                     },
                     move |result| match result {
                         Ok(created) => {
-                            status.set_text(&format!(
-                                "Vault created. Recovery words:\n{}",
-                                &*created.recovery_words
-                            ));
+                            // SECURITY: never surface the recovery words on
+                            // the persistent status_label. Show them once in
+                            // a modal dialog the user must acknowledge, then
+                            // drop the Zeroizing<String> to wipe the buffer.
+                            status.set_text("Vault created.");
+                            show_recovery_words_dialog(&parent, created.recovery_words, || {});
                         }
                         Err(e) => status.set_text(&format!("Error: {}", e)),
                     },

--- a/clients/linux/src/ui/unlock.rs
+++ b/clients/linux/src/ui/unlock.rs
@@ -96,7 +96,7 @@ impl UnlockView {
                     move |service| async move {
                         service
                             .open_vault(OpenVaultParams {
-                                password,
+                                password: zeroize::Zeroizing::new(password),
                                 provider_type: "local".to_string(),
                                 provider_config: serde_json::json!({ "root": path }),
                             })
@@ -142,7 +142,7 @@ impl UnlockView {
                         service
                             .create_vault(axiomvault_app::CreateVaultParams {
                                 vault_id: vault_name,
-                                password,
+                                password: zeroize::Zeroizing::new(password),
                                 provider_type: "local".to_string(),
                                 provider_config: serde_json::json!({ "root": path }),
                             })
@@ -152,7 +152,7 @@ impl UnlockView {
                         Ok(created) => {
                             status.set_text(&format!(
                                 "Vault created. Recovery words:\n{}",
-                                created.recovery_words
+                                &*created.recovery_words
                             ));
                         }
                         Err(e) => status.set_text(&format!("Error: {}", e)),

--- a/core/app/src/dto.rs
+++ b/core/app/src/dto.rs
@@ -5,7 +5,7 @@
 
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
-use zeroize::{Zeroize, ZeroizeOnDrop};
+use zeroize::Zeroizing;
 
 /// Information about an open vault.
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -19,12 +19,17 @@ pub struct VaultInfoDto {
 }
 
 /// Result of vault creation, including the recovery words.
-#[derive(Debug, Clone, Serialize, Deserialize)]
+///
+/// `recovery_words` is wrapped in [`Zeroizing`] so the mnemonic is wiped
+/// from memory when this DTO (or any clone of it) is dropped. The field
+/// is intentionally not `Serialize`/`Deserialize`-able to discourage callers
+/// from logging or persisting the secret.
+#[derive(Debug)]
 pub struct VaultCreatedDto {
     /// Vault info.
     pub info: VaultInfoDto,
     /// BIP39 recovery words (24 words). Must be shown to user exactly once.
-    pub recovery_words: String,
+    pub recovery_words: Zeroizing<String>,
 }
 
 /// A single entry in a directory listing.
@@ -56,45 +61,48 @@ pub struct FileMetadataDto {
 }
 
 /// Parameters for creating a new vault.
-#[derive(Debug, Serialize, Deserialize, Zeroize, ZeroizeOnDrop)]
+///
+/// `password` is held in [`Zeroizing`] so the secret is wiped from memory
+/// when the params are dropped. The struct intentionally does not implement
+/// `Serialize`/`Deserialize` because callers should never persist or log it.
+#[derive(Debug)]
 pub struct CreateVaultParams {
     /// Vault identifier.
-    #[zeroize(skip)]
     pub vault_id: String,
     /// Password for the vault.
-    pub password: String,
+    pub password: Zeroizing<String>,
     /// Storage provider type.
-    #[zeroize(skip)]
     pub provider_type: String,
     /// Provider-specific configuration.
-    #[zeroize(skip)]
     pub provider_config: serde_json::Value,
 }
 
 /// Parameters for opening an existing vault.
-#[derive(Debug, Serialize, Deserialize, Zeroize, ZeroizeOnDrop)]
+///
+/// `password` is held in [`Zeroizing`] so the secret is wiped from memory
+/// when the params are dropped.
+#[derive(Debug)]
 pub struct OpenVaultParams {
     /// Password for the vault.
-    pub password: String,
+    pub password: Zeroizing<String>,
     /// Storage provider type.
-    #[zeroize(skip)]
     pub provider_type: String,
     /// Provider-specific configuration.
-    #[zeroize(skip)]
     pub provider_config: serde_json::Value,
 }
 
 /// Parameters for recovering a vault with recovery words.
-#[derive(Debug, Serialize, Deserialize, Zeroize, ZeroizeOnDrop)]
+///
+/// Both `recovery_words` and `new_password` are held in [`Zeroizing`] so the
+/// secrets are wiped from memory when the params are dropped.
+#[derive(Debug)]
 pub struct RecoverVaultParams {
     /// BIP39 recovery words.
-    pub recovery_words: String,
+    pub recovery_words: Zeroizing<String>,
     /// New password.
-    pub new_password: String,
+    pub new_password: Zeroizing<String>,
     /// Storage provider type.
-    #[zeroize(skip)]
     pub provider_type: String,
     /// Provider-specific configuration.
-    #[zeroize(skip)]
     pub provider_config: serde_json::Value,
 }

--- a/core/app/src/dto.rs
+++ b/core/app/src/dto.rs
@@ -2,6 +2,15 @@
 //!
 //! DTOs are plain, serializable structs that cross the FFI/bridge boundary.
 //! They carry no behavior and no references to internal domain types.
+//!
+//! # Debug formatting
+//!
+//! `zeroize::Zeroizing<T>` *does* implement `Debug` by delegating to inner `T`,
+//! so a derived `#[derive(Debug)]` on a struct holding `Zeroizing<String>`
+//! would print the password / mnemonic in plaintext. The DTOs in this module
+//! that hold secrets therefore implement `Debug` by hand and print
+//! `[REDACTED]` for the secret fields, matching `MasterKey` / `FileKey` /
+//! `CloudTokens` elsewhere in the codebase.
 
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
@@ -21,15 +30,27 @@ pub struct VaultInfoDto {
 /// Result of vault creation, including the recovery words.
 ///
 /// `recovery_words` is wrapped in [`Zeroizing`] so the mnemonic is wiped
-/// from memory when this DTO (or any clone of it) is dropped. The field
-/// is intentionally not `Serialize`/`Deserialize`-able to discourage callers
-/// from logging or persisting the secret.
-#[derive(Debug)]
+/// from memory when this DTO is dropped. The field is intentionally not
+/// `Serialize`/`Deserialize`-able to discourage callers from logging or
+/// persisting the secret. `Clone` is intentionally not derived so the
+/// mnemonic cannot accidentally proliferate across the FFI boundary.
+///
+/// `Debug` is implemented by hand and redacts `recovery_words` — see the
+/// module-level note about `Zeroizing<T>` and `Debug` (audit hardening).
 pub struct VaultCreatedDto {
     /// Vault info.
     pub info: VaultInfoDto,
     /// BIP39 recovery words (24 words). Must be shown to user exactly once.
     pub recovery_words: Zeroizing<String>,
+}
+
+impl std::fmt::Debug for VaultCreatedDto {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("VaultCreatedDto")
+            .field("info", &self.info)
+            .field("recovery_words", &"[REDACTED]")
+            .finish()
+    }
 }
 
 /// A single entry in a directory listing.
@@ -65,7 +86,9 @@ pub struct FileMetadataDto {
 /// `password` is held in [`Zeroizing`] so the secret is wiped from memory
 /// when the params are dropped. The struct intentionally does not implement
 /// `Serialize`/`Deserialize` because callers should never persist or log it.
-#[derive(Debug)]
+///
+/// `Debug` is implemented by hand and redacts `password` — see the
+/// module-level note about `Zeroizing<T>` and `Debug`.
 pub struct CreateVaultParams {
     /// Vault identifier.
     pub vault_id: String,
@@ -77,11 +100,24 @@ pub struct CreateVaultParams {
     pub provider_config: serde_json::Value,
 }
 
+impl std::fmt::Debug for CreateVaultParams {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("CreateVaultParams")
+            .field("vault_id", &self.vault_id)
+            .field("password", &"[REDACTED]")
+            .field("provider_type", &self.provider_type)
+            .field("provider_config", &self.provider_config)
+            .finish()
+    }
+}
+
 /// Parameters for opening an existing vault.
 ///
 /// `password` is held in [`Zeroizing`] so the secret is wiped from memory
 /// when the params are dropped.
-#[derive(Debug)]
+///
+/// `Debug` is implemented by hand and redacts `password` — see the
+/// module-level note about `Zeroizing<T>` and `Debug`.
 pub struct OpenVaultParams {
     /// Password for the vault.
     pub password: Zeroizing<String>,
@@ -91,11 +127,23 @@ pub struct OpenVaultParams {
     pub provider_config: serde_json::Value,
 }
 
+impl std::fmt::Debug for OpenVaultParams {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("OpenVaultParams")
+            .field("password", &"[REDACTED]")
+            .field("provider_type", &self.provider_type)
+            .field("provider_config", &self.provider_config)
+            .finish()
+    }
+}
+
 /// Parameters for recovering a vault with recovery words.
 ///
 /// Both `recovery_words` and `new_password` are held in [`Zeroizing`] so the
 /// secrets are wiped from memory when the params are dropped.
-#[derive(Debug)]
+///
+/// `Debug` is implemented by hand and redacts both secret fields — see the
+/// module-level note about `Zeroizing<T>` and `Debug`.
 pub struct RecoverVaultParams {
     /// BIP39 recovery words.
     pub recovery_words: Zeroizing<String>,
@@ -105,4 +153,122 @@ pub struct RecoverVaultParams {
     pub provider_type: String,
     /// Provider-specific configuration.
     pub provider_config: serde_json::Value,
+}
+
+impl std::fmt::Debug for RecoverVaultParams {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("RecoverVaultParams")
+            .field("recovery_words", &"[REDACTED]")
+            .field("new_password", &"[REDACTED]")
+            .field("provider_type", &self.provider_type)
+            .field("provider_config", &self.provider_config)
+            .finish()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Audit hardening: `Zeroizing<T>` delegates `Debug` to inner `T`, so a
+    /// derived `Debug` on these DTOs would print the password / mnemonic in
+    /// plaintext. The hand-rolled `Debug` impls must redact secrets.
+    #[test]
+    fn create_vault_params_debug_redacts_password() {
+        let params = CreateVaultParams {
+            vault_id: "vault-1".to_string(),
+            password: Zeroizing::new("super-secret-password-do-not-print".to_string()),
+            provider_type: "local".to_string(),
+            provider_config: serde_json::json!({}),
+        };
+        let s = format!("{:?}", params);
+        assert!(
+            !s.contains("super-secret-password-do-not-print"),
+            "CreateVaultParams Debug leaked password: {}",
+            s
+        );
+        assert!(
+            s.contains("[REDACTED]"),
+            "CreateVaultParams Debug should mark redacted fields: {}",
+            s
+        );
+        // Non-secret fields should still be visible.
+        assert!(s.contains("vault-1"));
+        assert!(s.contains("local"));
+    }
+
+    #[test]
+    fn open_vault_params_debug_redacts_password() {
+        let params = OpenVaultParams {
+            password: Zeroizing::new("another-secret-passphrase".to_string()),
+            provider_type: "gdrive".to_string(),
+            provider_config: serde_json::json!({"folder": "vault"}),
+        };
+        let s = format!("{:?}", params);
+        assert!(
+            !s.contains("another-secret-passphrase"),
+            "OpenVaultParams Debug leaked password: {}",
+            s
+        );
+        assert!(s.contains("[REDACTED]"));
+        assert!(s.contains("gdrive"));
+    }
+
+    #[test]
+    fn recover_vault_params_debug_redacts_both_secrets() {
+        let params = RecoverVaultParams {
+            recovery_words: Zeroizing::new(
+                "abandon ability able about above absent absorb abstract absurd abuse access \
+                 accident account accuse achieve acid acoustic acquire across act action actor \
+                 actress actual"
+                    .to_string(),
+            ),
+            new_password: Zeroizing::new("brand-new-password-456".to_string()),
+            provider_type: "local".to_string(),
+            provider_config: serde_json::json!({}),
+        };
+        let s = format!("{:?}", params);
+        assert!(
+            !s.contains("abandon ability"),
+            "RecoverVaultParams Debug leaked recovery_words: {}",
+            s
+        );
+        assert!(
+            !s.contains("brand-new-password-456"),
+            "RecoverVaultParams Debug leaked new_password: {}",
+            s
+        );
+        // Both fields should appear as [REDACTED].
+        let redacted_count = s.matches("[REDACTED]").count();
+        assert!(
+            redacted_count >= 2,
+            "RecoverVaultParams Debug should redact both secret fields, got `{}`",
+            s
+        );
+    }
+
+    #[test]
+    fn vault_created_dto_debug_redacts_recovery_words() {
+        let dto = VaultCreatedDto {
+            info: VaultInfoDto {
+                id: "vault-1".to_string(),
+                provider_type: "local".to_string(),
+                is_unlocked: true,
+            },
+            recovery_words: Zeroizing::new(
+                "abandon ability able about above absent absorb abstract absurd abuse access \
+                 accident"
+                    .to_string(),
+            ),
+        };
+        let s = format!("{:?}", dto);
+        assert!(
+            !s.contains("abandon ability"),
+            "VaultCreatedDto Debug leaked recovery_words: {}",
+            s
+        );
+        assert!(s.contains("[REDACTED]"));
+        // Non-secret info should still be visible.
+        assert!(s.contains("vault-1"));
+    }
 }

--- a/core/app/src/dto.rs
+++ b/core/app/src/dto.rs
@@ -14,7 +14,28 @@
 
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
-use zeroize::Zeroizing;
+use zeroize::{Zeroize, Zeroizing};
+
+fn zeroize_json_value(value: &mut serde_json::Value) {
+    match value {
+        serde_json::Value::Null | serde_json::Value::Bool(_) | serde_json::Value::Number(_) => {}
+        serde_json::Value::String(s) => s.zeroize(),
+        serde_json::Value::Array(items) => {
+            for item in items.iter_mut() {
+                zeroize_json_value(item);
+            }
+            items.clear();
+        }
+        serde_json::Value::Object(map) => {
+            let entries = std::mem::take(map);
+            for (mut key, mut item) in entries {
+                key.zeroize();
+                zeroize_json_value(&mut item);
+            }
+        }
+    }
+    *value = serde_json::Value::Null;
+}
 
 /// Information about an open vault.
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -104,6 +125,12 @@ pub struct CreateVaultParams {
     pub provider_config: serde_json::Value,
 }
 
+impl Drop for CreateVaultParams {
+    fn drop(&mut self) {
+        zeroize_json_value(&mut self.provider_config);
+    }
+}
+
 impl std::fmt::Debug for CreateVaultParams {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("CreateVaultParams")
@@ -130,6 +157,12 @@ pub struct OpenVaultParams {
     pub provider_type: String,
     /// Provider-specific configuration.
     pub provider_config: serde_json::Value,
+}
+
+impl Drop for OpenVaultParams {
+    fn drop(&mut self) {
+        zeroize_json_value(&mut self.provider_config);
+    }
 }
 
 impl std::fmt::Debug for OpenVaultParams {
@@ -161,6 +194,12 @@ pub struct RecoverVaultParams {
     pub provider_config: serde_json::Value,
 }
 
+impl Drop for RecoverVaultParams {
+    fn drop(&mut self) {
+        zeroize_json_value(&mut self.provider_config);
+    }
+}
+
 impl std::fmt::Debug for RecoverVaultParams {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("RecoverVaultParams")
@@ -175,6 +214,18 @@ impl std::fmt::Debug for RecoverVaultParams {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn zeroize_json_value_clears_nested_secret_strings() {
+        let mut value = serde_json::json!({
+            "access_token": "secret-access-token",
+            "nested": ["refresh-token", {"api_key": "secret-api-key"}],
+        });
+
+        zeroize_json_value(&mut value);
+
+        assert_eq!(value, serde_json::Value::Null);
+    }
 
     /// Audit hardening: `Zeroizing<T>` delegates `Debug` to inner `T`, so a
     /// derived `Debug` on these DTOs would print the password / mnemonic in

--- a/core/app/src/dto.rs
+++ b/core/app/src/dto.rs
@@ -87,8 +87,12 @@ pub struct FileMetadataDto {
 /// when the params are dropped. The struct intentionally does not implement
 /// `Serialize`/`Deserialize` because callers should never persist or log it.
 ///
-/// `Debug` is implemented by hand and redacts `password` — see the
-/// module-level note about `Zeroizing<T>` and `Debug`.
+/// `Debug` is implemented by hand and redacts `password` and
+/// `provider_config` — see the module-level note about `Zeroizing<T>` and
+/// `Debug`. `provider_config` is redacted because providers (OAuth2 clients,
+/// custom backends) may carry tokens / refresh tokens / API keys in this
+/// blob; treating it as opaque-and-secret in Debug output is the safe
+/// default.
 pub struct CreateVaultParams {
     /// Vault identifier.
     pub vault_id: String,
@@ -106,7 +110,7 @@ impl std::fmt::Debug for CreateVaultParams {
             .field("vault_id", &self.vault_id)
             .field("password", &"[REDACTED]")
             .field("provider_type", &self.provider_type)
-            .field("provider_config", &self.provider_config)
+            .field("provider_config", &"[REDACTED]")
             .finish()
     }
 }
@@ -116,8 +120,9 @@ impl std::fmt::Debug for CreateVaultParams {
 /// `password` is held in [`Zeroizing`] so the secret is wiped from memory
 /// when the params are dropped.
 ///
-/// `Debug` is implemented by hand and redacts `password` — see the
-/// module-level note about `Zeroizing<T>` and `Debug`.
+/// `Debug` is implemented by hand and redacts `password` and
+/// `provider_config` — see the `CreateVaultParams` doc and the module-level
+/// note for the rationale.
 pub struct OpenVaultParams {
     /// Password for the vault.
     pub password: Zeroizing<String>,
@@ -132,7 +137,7 @@ impl std::fmt::Debug for OpenVaultParams {
         f.debug_struct("OpenVaultParams")
             .field("password", &"[REDACTED]")
             .field("provider_type", &self.provider_type)
-            .field("provider_config", &self.provider_config)
+            .field("provider_config", &"[REDACTED]")
             .finish()
     }
 }
@@ -142,8 +147,9 @@ impl std::fmt::Debug for OpenVaultParams {
 /// Both `recovery_words` and `new_password` are held in [`Zeroizing`] so the
 /// secrets are wiped from memory when the params are dropped.
 ///
-/// `Debug` is implemented by hand and redacts both secret fields — see the
-/// module-level note about `Zeroizing<T>` and `Debug`.
+/// `Debug` is implemented by hand and redacts both secret fields plus
+/// `provider_config` — see the `CreateVaultParams` doc and the module-level
+/// note for the rationale.
 pub struct RecoverVaultParams {
     /// BIP39 recovery words.
     pub recovery_words: Zeroizing<String>,
@@ -161,7 +167,7 @@ impl std::fmt::Debug for RecoverVaultParams {
             .field("recovery_words", &"[REDACTED]")
             .field("new_password", &"[REDACTED]")
             .field("provider_type", &self.provider_type)
-            .field("provider_config", &self.provider_config)
+            .field("provider_config", &"[REDACTED]")
             .finish()
     }
 }
@@ -202,12 +208,17 @@ mod tests {
         let params = OpenVaultParams {
             password: Zeroizing::new("another-secret-passphrase".to_string()),
             provider_type: "gdrive".to_string(),
-            provider_config: serde_json::json!({"folder": "vault"}),
+            provider_config: serde_json::json!({"folder": "vault-secret-folder-id"}),
         };
         let s = format!("{:?}", params);
         assert!(
             !s.contains("another-secret-passphrase"),
             "OpenVaultParams Debug leaked password: {}",
+            s
+        );
+        assert!(
+            !s.contains("vault-secret-folder-id"),
+            "OpenVaultParams Debug leaked provider_config: {}",
             s
         );
         assert!(s.contains("[REDACTED]"));

--- a/core/app/src/error.rs
+++ b/core/app/src/error.rs
@@ -83,6 +83,7 @@ impl From<CommonError> for AppError {
             CommonError::Storage(msg) => AppError::Storage(msg),
             CommonError::Network(msg) => AppError::Storage(msg),
             CommonError::Authentication(msg) => AppError::Storage(msg),
+            CommonError::AuthenticationExpired(msg) => AppError::Storage(msg),
             CommonError::Io(err) => AppError::Storage(err.to_string()),
             CommonError::Serialization(msg) => AppError::Internal(msg),
             CommonError::Vault(msg) => AppError::Internal(msg),

--- a/core/app/src/service.rs
+++ b/core/app/src/service.rs
@@ -4,6 +4,7 @@ use std::sync::Arc;
 
 use tokio::sync::{RwLock, RwLockReadGuard};
 use tracing::info;
+use zeroize::Zeroizing;
 
 use axiomvault_common::{VaultId, VaultPath};
 use axiomvault_crypto::KdfParams;
@@ -134,9 +135,11 @@ impl AppService {
             is_unlocked: true,
         };
 
+        // Move the mnemonic out of the manager response and into the DTO so the
+        // bytes are never copied into a non-zeroizing buffer.
         let dto = VaultCreatedDto {
             info: info.clone(),
-            recovery_words: String::from(&*creation.recovery_words),
+            recovery_words: creation.recovery_words,
         };
 
         *self.session.write().await = Some(ActiveVault {
@@ -265,8 +268,14 @@ impl AppService {
 
     /// Change the vault password.
     ///
-    /// Requires exclusive access to the session — FUSE must be unmounted first.
-    pub async fn change_password(&self, old_password: &str, new_password: &str) -> AppResult<()> {
+    /// Both passwords are taken by value as [`Zeroizing<String>`] so they are
+    /// wiped from memory on return, regardless of success or failure. Requires
+    /// exclusive access to the session — FUSE must be unmounted first.
+    pub async fn change_password(
+        &self,
+        old_password: Zeroizing<String>,
+        new_password: Zeroizing<String>,
+    ) -> AppResult<()> {
         let mut guard = self.session.write().await;
         let active = guard.as_mut().ok_or(AppError::NoOpenVault)?;
 
@@ -278,6 +287,11 @@ impl AppService {
         session
             .change_password(old_password.as_bytes(), new_password.as_bytes())
             .map_err(AppError::from)?;
+
+        // Drop both passwords as soon as the underlying call returns. The
+        // `Zeroizing` wrapper wipes the heap allocation on drop.
+        drop(old_password);
+        drop(new_password);
 
         // Persist the updated config.
         self.manager
@@ -594,7 +608,7 @@ mod tests {
         let result = service
             .create_vault(CreateVaultParams {
                 vault_id: "test-vault".to_string(),
-                password: "secure-password".to_string(),
+                password: Zeroizing::new("secure-password".to_string()),
                 provider_type: "memory".to_string(),
                 provider_config: serde_json::Value::Null,
             })
@@ -617,7 +631,7 @@ mod tests {
         service
             .create_vault(CreateVaultParams {
                 vault_id: "test-vault".to_string(),
-                password: "password".to_string(),
+                password: Zeroizing::new("password".to_string()),
                 provider_type: "memory".to_string(),
                 provider_config: serde_json::Value::Null,
             })
@@ -654,7 +668,7 @@ mod tests {
         service
             .create_vault(CreateVaultParams {
                 vault_id: "test-vault".to_string(),
-                password: "password".to_string(),
+                password: Zeroizing::new("password".to_string()),
                 provider_type: "memory".to_string(),
                 provider_config: serde_json::Value::Null,
             })
@@ -680,7 +694,7 @@ mod tests {
         service
             .create_vault(CreateVaultParams {
                 vault_id: "test-vault".to_string(),
-                password: "password".to_string(),
+                password: Zeroizing::new("password".to_string()),
                 provider_type: "memory".to_string(),
                 provider_config: serde_json::Value::Null,
             })
@@ -722,7 +736,7 @@ mod tests {
 
         let result = service
             .open_vault(OpenVaultParams {
-                password: "password".to_string(),
+                password: Zeroizing::new("password".to_string()),
                 provider_type: "memory".to_string(),
                 provider_config: serde_json::Value::Null,
             })
@@ -752,7 +766,7 @@ mod tests {
         service
             .create_vault(CreateVaultParams {
                 vault_id: "test-vault".to_string(),
-                password: "old-password".to_string(),
+                password: Zeroizing::new("old-password".to_string()),
                 provider_type: "memory".to_string(),
                 provider_config: serde_json::Value::Null,
             })
@@ -760,7 +774,10 @@ mod tests {
             .unwrap();
 
         service
-            .change_password("old-password", "new-password")
+            .change_password(
+                Zeroizing::new("old-password".to_string()),
+                Zeroizing::new("new-password".to_string()),
+            )
             .await
             .unwrap();
 

--- a/core/app/tests/app_service_contract.rs
+++ b/core/app/tests/app_service_contract.rs
@@ -7,6 +7,7 @@ use axiomvault_app::{
     AppError, AppEvent, AppService, CreateVaultParams, LocalIndex, OpenVaultParams,
     RecoverVaultParams,
 };
+use zeroize::Zeroizing;
 
 // ---------------------------------------------------------------------------
 // Fixtures
@@ -15,7 +16,7 @@ use axiomvault_app::{
 fn memory_params(vault_id: &str, password: &str) -> CreateVaultParams {
     CreateVaultParams {
         vault_id: vault_id.to_string(),
-        password: password.to_string(),
+        password: Zeroizing::new(password.to_string()),
         provider_type: "memory".to_string(),
         provider_config: serde_json::Value::Null,
     }
@@ -23,7 +24,7 @@ fn memory_params(vault_id: &str, password: &str) -> CreateVaultParams {
 
 fn memory_open_params(password: &str) -> OpenVaultParams {
     OpenVaultParams {
-        password: password.to_string(),
+        password: Zeroizing::new(password.to_string()),
         provider_type: "memory".to_string(),
         provider_config: serde_json::Value::Null,
     }
@@ -72,7 +73,7 @@ async fn create_duplicate_vault_fails() {
 
     svc.create_vault(CreateVaultParams {
         vault_id: "dup".to_string(),
-        password: "pass".to_string(),
+        password: Zeroizing::new("pass".to_string()),
         provider_type: "local".to_string(),
         provider_config: config.clone(),
     })
@@ -84,7 +85,7 @@ async fn create_duplicate_vault_fails() {
     let err = svc
         .create_vault(CreateVaultParams {
             vault_id: "dup".to_string(),
-            password: "pass".to_string(),
+            password: Zeroizing::new("pass".to_string()),
             provider_type: "local".to_string(),
             provider_config: config,
         })
@@ -179,7 +180,7 @@ async fn recover_vault_with_valid_words() {
     let created = svc
         .create_vault(CreateVaultParams {
             vault_id: "rec".to_string(),
-            password: "old-pass".to_string(),
+            password: Zeroizing::new("old-pass".to_string()),
             provider_type: "local".to_string(),
             provider_config: config.clone(),
         })
@@ -194,7 +195,7 @@ async fn recover_vault_with_valid_words() {
     let info = svc
         .recover_vault(RecoverVaultParams {
             recovery_words: words,
-            new_password: "new-pass".to_string(),
+            new_password: Zeroizing::new("new-pass".to_string()),
             provider_type: "local".to_string(),
             provider_config: config,
         })
@@ -217,7 +218,7 @@ async fn recover_vault_with_wrong_words_fails() {
 
     svc.create_vault(CreateVaultParams {
         vault_id: "rec2".to_string(),
-        password: "pass".to_string(),
+        password: Zeroizing::new("pass".to_string()),
         provider_type: "local".to_string(),
         provider_config: config.clone(),
     })
@@ -227,8 +228,8 @@ async fn recover_vault_with_wrong_words_fails() {
 
     let err = svc
         .recover_vault(RecoverVaultParams {
-            recovery_words: "abandon ".repeat(24).trim().to_string(),
-            new_password: "new".to_string(),
+            recovery_words: Zeroizing::new("abandon ".repeat(24).trim().to_string()),
+            new_password: Zeroizing::new("new".to_string()),
             provider_type: "local".to_string(),
             provider_config: config,
         })
@@ -254,9 +255,12 @@ async fn change_password_allows_new_password() {
     let svc = service_with_vault().await;
     svc.create_file("/test.txt", b"hello").await.unwrap();
 
-    svc.change_password("password", "new-password")
-        .await
-        .unwrap();
+    svc.change_password(
+        Zeroizing::new("password".to_string()),
+        Zeroizing::new("new-password".to_string()),
+    )
+    .await
+    .unwrap();
 
     // File should still be readable.
     let content = svc.read_file("/test.txt").await.unwrap();
@@ -266,7 +270,13 @@ async fn change_password_allows_new_password() {
 #[tokio::test]
 async fn change_password_with_wrong_old_password_fails() {
     let svc = service_with_vault().await;
-    let err = svc.change_password("wrong", "new").await.unwrap_err();
+    let err = svc
+        .change_password(
+            Zeroizing::new("wrong".to_string()),
+            Zeroizing::new("new".to_string()),
+        )
+        .await
+        .unwrap_err();
     assert!(
         matches!(err, AppError::InvalidPassword | AppError::Crypto(_)),
         "expected InvalidPassword or Crypto, got {:?}",
@@ -580,7 +590,12 @@ async fn password_change_event() {
     let svc = service_with_vault().await;
     let mut rx = svc.subscribe();
 
-    svc.change_password("password", "new").await.unwrap();
+    svc.change_password(
+        Zeroizing::new("password".to_string()),
+        Zeroizing::new("new".to_string()),
+    )
+    .await
+    .unwrap();
     assert!(matches!(rx.try_recv().unwrap(), AppEvent::PasswordChanged));
 }
 
@@ -632,7 +647,11 @@ async fn operations_fail_without_vault() {
         Err(AppError::NoOpenVault)
     ));
     assert!(matches!(
-        svc.change_password("a", "b").await,
+        svc.change_password(
+            Zeroizing::new("a".to_string()),
+            Zeroizing::new("b".to_string())
+        )
+        .await,
         Err(AppError::NoOpenVault)
     ));
     assert!(matches!(
@@ -766,7 +785,7 @@ async fn vault_exists_before_and_after_create() {
 
     svc.create_vault(CreateVaultParams {
         vault_id: "ex".to_string(),
-        password: "pass".to_string(),
+        password: Zeroizing::new("pass".to_string()),
         provider_type: "local".to_string(),
         provider_config: config.clone(),
     })

--- a/core/common/src/error.rs
+++ b/core/common/src/error.rs
@@ -45,9 +45,23 @@ pub enum Error {
     #[error("Conflict: {0}")]
     Conflict(String),
 
-    /// Authentication failed.
+    /// Authentication failed permanently.
+    ///
+    /// Used for non-transient auth failures where retrying will not help:
+    /// invalid credentials, revoked tokens, failed OAuth token exchange,
+    /// failed refresh-token redemption, permission denials that surface
+    /// as auth errors, etc.
     #[error("Authentication error: {0}")]
     Authentication(String),
+
+    /// Authentication failed transiently — token expired or needs refresh.
+    ///
+    /// Used when the server indicates the current access token is no
+    /// longer valid (typically HTTP 401) but the refresh token is still
+    /// believed to be good. Callers wrapped by the retry executor will
+    /// re-attempt, giving the token manager a chance to refresh.
+    #[error("Authentication expired: {0}")]
+    AuthenticationExpired(String),
 
     /// Network operation failed.
     #[error("Network error: {0}")]

--- a/core/ffi/Cargo.toml
+++ b/core/ffi/Cargo.toml
@@ -28,6 +28,9 @@ serde_json.workspace = true
 tracing.workspace = true
 tracing-subscriber.workspace = true
 
+# Wipe password / mnemonic buffers crossing the FFI boundary.
+zeroize.workspace = true
+
 # For C FFI
 once_cell = "1.18"
 

--- a/core/ffi/src/lib.rs
+++ b/core/ffi/src/lib.rs
@@ -830,22 +830,18 @@ pub unsafe extern "C" fn axiom_recovery_words_free(s: *mut c_char) {
     // takes back ownership of the same allocation and won't be called twice.
     let cstring = CString::from_raw(s);
 
-    // Convert into an owned `Vec<u8>` so we can mutate via a legitimate
-    // `as_mut_ptr()`. Writing through a `*mut` derived from `&[u8]` (as the
-    // previous implementation did via `cstring.as_bytes_with_nul().as_ptr()
-    // as *mut u8`) violates Rust's aliasing model: the optimizer is allowed
-    // to assume bytes behind a shared reference are not mutated, and could
-    // elide the wipe entirely — turning this security-critical zeroization
-    // into a no-op. Owning a `Vec` makes the mutation legitimate.
+    // Convert into an owned `Vec<u8>` so the wipe operates on memory we own.
+    // Writing through a `*mut` derived from `&[u8]` (as an earlier version
+    // did via `cstring.as_bytes_with_nul().as_ptr() as *mut u8`) violates
+    // Rust's aliasing model. We could fall back to `ptr::write_bytes` plus a
+    // `compiler_fence`, but the compiler is still permitted to elide a write
+    // it considers a dead store (the bytes are dropped immediately after).
+    // `zeroize::Zeroize` is the standard primitive for exactly this case:
+    // its implementation uses volatile writes that the optimizer must not
+    // remove.
+    use zeroize::Zeroize;
     let mut bytes = cstring.into_bytes_with_nul();
-    let len = bytes.len();
-    let ptr = bytes.as_mut_ptr();
-    // SAFETY: `ptr` points to `len` bytes owned by `bytes`; exclusive access
-    // is guaranteed because we own the `Vec`. The compiler_fence prevents the
-    // wipe from being reordered past the subsequent deallocation.
-    std::ptr::write_bytes(ptr, 0, len);
-    std::sync::atomic::compiler_fence(std::sync::atomic::Ordering::SeqCst);
-
+    bytes.zeroize();
     drop(bytes);
 }
 

--- a/core/ffi/src/lib.rs
+++ b/core/ffi/src/lib.rs
@@ -29,6 +29,8 @@ pub mod vault_ops;
 use std::ffi::{c_char, c_int, CStr, CString};
 use std::ptr;
 
+use zeroize::Zeroizing;
+
 use crate::error::FFIError;
 use crate::runtime::get_runtime;
 use crate::types::{FFIEventCallback, FFIVaultHandle, FFIVaultInfo};
@@ -38,6 +40,12 @@ use crate::types::{FFIEventCallback, FFIVaultHandle, FFIVaultInfo};
 // ---------------------------------------------------------------------------
 
 /// Extract a `&str` from a C string pointer, setting the FFI error on failure.
+///
+/// # Safety
+/// The caller must ensure `ptr` is either null or points to a valid
+/// NUL-terminated C string that lives at least as long as the returned `&str`.
+// SAFETY: contract documented above; callers in this module pass pointers
+// supplied by the FFI consumer, which we treat as opaque per the C-ABI contract.
 unsafe fn str_from_ptr<'a>(ptr: *const c_char, name: &str) -> Option<&'a str> {
     if ptr.is_null() {
         error::set_last_error(FFIError::NullPointer(format!("{} is null", name)));
@@ -50,6 +58,33 @@ unsafe fn str_from_ptr<'a>(ptr: *const c_char, name: &str) -> Option<&'a str> {
             None
         }
     }
+}
+
+/// Copy a C string into a freshly allocated [`Zeroizing<String>`], setting
+/// the FFI error on failure. The caller-provided buffer is *not* mutated;
+/// the new owned `Zeroizing<String>` will wipe its bytes on drop.
+///
+/// # Safety
+/// Same contract as [`str_from_ptr`]: `ptr` must be null or point to a valid
+/// NUL-terminated C string.
+// SAFETY: contract delegated to `str_from_ptr` — the only unsafe operation
+// here is the inner `CStr::from_ptr` call inside that helper.
+unsafe fn zeroizing_string_from_ptr(ptr: *const c_char, name: &str) -> Option<Zeroizing<String>> {
+    let s = str_from_ptr(ptr, name)?;
+    Some(Zeroizing::new(s.to_owned()))
+}
+
+/// Copy a `Zeroizing<String>` (containing a recovery mnemonic or other secret)
+/// into a freshly allocated C-owned buffer, then zeroize the source.
+///
+/// The returned pointer must be freed by the caller via
+/// [`axiom_recovery_words_free`], which wipes the bytes before deallocating.
+fn into_secret_cstr(secret: Zeroizing<String>) -> Result<*mut c_char, FFIError> {
+    // CString::new copies into a fresh allocation and rejects interior NULs.
+    // After this, the original `secret` is dropped (and zeroed) at end of scope.
+    let cstring = CString::new(secret.as_bytes()).map_err(|_| FFIError::StringConversionError)?;
+    drop(secret);
+    Ok(cstring.into_raw())
 }
 
 /// Run an async operation on the global runtime, mapping errors to FFI.
@@ -129,12 +164,12 @@ pub unsafe extern "C" fn axiom_vault_create(
         Some(s) => s,
         None => return ptr::null_mut(),
     };
-    let password_str = match str_from_ptr(password, "password") {
+    let password_zeroizing = match zeroizing_string_from_ptr(password, "password") {
         Some(s) => s,
         None => return ptr::null_mut(),
     };
 
-    match block_on(vault_ops::create_vault(path_str, password_str)) {
+    match block_on(vault_ops::create_vault(path_str, password_zeroizing)) {
         Ok(handle) => Box::into_raw(Box::new(handle)),
         Err(()) => ptr::null_mut(),
     }
@@ -155,12 +190,12 @@ pub unsafe extern "C" fn axiom_vault_open(
         Some(s) => s,
         None => return ptr::null_mut(),
     };
-    let password_str = match str_from_ptr(password, "password") {
+    let password_zeroizing = match zeroizing_string_from_ptr(password, "password") {
         Some(s) => s,
         None => return ptr::null_mut(),
     };
 
-    match block_on(vault_ops::open_vault(path_str, password_str)) {
+    match block_on(vault_ops::open_vault(path_str, password_zeroizing)) {
         Ok(handle) => Box::into_raw(Box::new(handle)),
         Err(()) => ptr::null_mut(),
     }
@@ -412,16 +447,16 @@ pub unsafe extern "C" fn axiom_vault_change_password(
         error::set_last_error(FFIError::NullPointer("handle is null".into()));
         return -1;
     }
-    let old_str = match str_from_ptr(old_password, "old_password") {
+    let old_pw = match zeroizing_string_from_ptr(old_password, "old_password") {
         Some(s) => s,
         None => return -1,
     };
-    let new_str = match str_from_ptr(new_password, "new_password") {
+    let new_pw = match zeroizing_string_from_ptr(new_password, "new_password") {
         Some(s) => s,
         None => return -1,
     };
 
-    match block_on(vault_ops::change_password(&*handle, old_str, new_str)) {
+    match block_on(vault_ops::change_password(&*handle, old_pw, new_pw)) {
         Ok(()) => 0,
         Err(()) => -1,
     }
@@ -434,9 +469,13 @@ pub unsafe extern "C" fn axiom_vault_change_password(
 /// consumed by a previous call. **Words are cleared after retrieval** — this
 /// function returns them exactly once.
 ///
+/// The bytes inside the handle are kept in a `Zeroizing<String>` and are
+/// wiped immediately after being copied into the C-owned buffer.
+///
 /// # Safety
 /// - `handle` must be a valid vault handle
-/// - Returned string must be freed with `axiom_string_free`
+/// - Returned string must be freed with [`axiom_recovery_words_free`]
+///   (NOT `axiom_string_free` — recovery words require zeroizing free)
 #[no_mangle]
 pub unsafe extern "C" fn axiom_vault_get_recovery_words(
     handle: *const FFIVaultHandle,
@@ -453,19 +492,26 @@ pub unsafe extern "C" fn axiom_vault_get_recovery_words(
         .and_then(|mut guard| guard.take());
 
     match words {
-        Some(w) => CString::new(w).map(|s| s.into_raw()).unwrap_or_else(|_| {
-            error::set_last_error(FFIError::StringConversionError);
-            ptr::null_mut()
-        }),
+        Some(w) => match into_secret_cstr(w) {
+            Ok(ptr) => ptr,
+            Err(e) => {
+                error::set_last_error(e);
+                ptr::null_mut()
+            }
+        },
         None => ptr::null_mut(),
     }
 }
 
 /// Show recovery key for an open vault (requires active session).
 ///
+/// The mnemonic is held in a `Zeroizing<String>` end-to-end and is wiped
+/// immediately after being copied into the C-owned buffer.
+///
 /// # Safety
 /// - `handle` must be a valid vault handle
-/// - Returned string must be freed with `axiom_string_free`
+/// - Returned string must be freed with [`axiom_recovery_words_free`]
+///   (NOT `axiom_string_free` — recovery words require zeroizing free)
 #[no_mangle]
 pub unsafe extern "C" fn axiom_vault_show_recovery_key(
     handle: *const FFIVaultHandle,
@@ -476,12 +522,13 @@ pub unsafe extern "C" fn axiom_vault_show_recovery_key(
     }
 
     match block_on(vault_ops::show_recovery_key(&*handle)) {
-        Ok(words) => CString::new(words)
-            .map(|s| s.into_raw())
-            .unwrap_or_else(|_| {
-                error::set_last_error(FFIError::StringConversionError);
+        Ok(words) => match into_secret_cstr(words) {
+            Ok(ptr) => ptr,
+            Err(e) => {
+                error::set_last_error(e);
                 ptr::null_mut()
-            }),
+            }
+        },
         Err(()) => ptr::null_mut(),
     }
 }
@@ -503,16 +550,20 @@ pub unsafe extern "C" fn axiom_vault_reset_password(
         Some(s) => s,
         None => return ptr::null_mut(),
     };
-    let words_str = match str_from_ptr(recovery_words, "recovery_words") {
+    let words_zeroizing = match zeroizing_string_from_ptr(recovery_words, "recovery_words") {
         Some(s) => s,
         None => return ptr::null_mut(),
     };
-    let password_str = match str_from_ptr(new_password, "new_password") {
+    let password_zeroizing = match zeroizing_string_from_ptr(new_password, "new_password") {
         Some(s) => s,
         None => return ptr::null_mut(),
     };
 
-    match block_on(vault_ops::reset_password(path_str, words_str, password_str)) {
+    match block_on(vault_ops::reset_password(
+        path_str,
+        words_zeroizing,
+        password_zeroizing,
+    )) {
         Ok(handle) => Box::into_raw(Box::new(handle)),
         Err(()) => ptr::null_mut(),
     }
@@ -715,6 +766,10 @@ pub extern "C" fn axiom_last_error() -> *mut c_char {
 
 /// Free a string returned by an FFI function.
 ///
+/// Do **not** use this for strings containing secrets — use the dedicated
+/// [`axiom_recovery_words_free`] for recovery mnemonics. Callers that pass
+/// a password or mnemonic here will leak the bytes to libc's allocator.
+///
 /// # Safety
 /// - `s` must be a valid pointer returned by an axiom FFI function
 /// - After this call, the pointer is invalid
@@ -722,5 +777,123 @@ pub extern "C" fn axiom_last_error() -> *mut c_char {
 pub unsafe extern "C" fn axiom_string_free(s: *mut c_char) {
     if !s.is_null() {
         let _ = CString::from_raw(s);
+    }
+}
+
+/// Free a recovery-words string returned by [`axiom_vault_get_recovery_words`]
+/// or [`axiom_vault_show_recovery_key`], zeroing the underlying bytes before
+/// releasing the allocation.
+///
+/// This is required (instead of [`axiom_string_free`]) because BIP39 recovery
+/// words can reconstruct the vault master key. Leaving them in freed heap
+/// memory is equivalent to leaking the credential.
+///
+/// Passing a pointer obtained from any other FFI function is undefined
+/// behavior.
+///
+/// # Safety
+/// - `s` must be a valid pointer returned by `axiom_vault_get_recovery_words`
+///   or `axiom_vault_show_recovery_key`
+/// - After this call, the pointer is invalid
+#[no_mangle]
+pub unsafe extern "C" fn axiom_recovery_words_free(s: *mut c_char) {
+    if s.is_null() {
+        return;
+    }
+    // Reclaim ownership of the allocation FIRST so its internal length is
+    // recovered from the (still-intact) NUL terminator. Zeroizing before
+    // `from_raw` would cause `strlen` to see length 0 and the allocator
+    // would only free 1 byte.
+    //
+    // SAFETY: The caller must ensure `s` came from a recovery-words FFI
+    // function, which allocated it via `CString::into_raw`. `from_raw` thus
+    // takes back ownership of the same allocation and won't be called twice.
+    let cstring = CString::from_raw(s);
+
+    // Overwrite the bytes (including the NUL terminator) in place, through
+    // the pointer we still hold. This uses a volatile-style write via
+    // `write_bytes` plus a compiler fence to prevent the writes being elided
+    // by the optimizer before the subsequent free.
+    let bytes = cstring.as_bytes_with_nul();
+    let len = bytes.len();
+    let ptr = bytes.as_ptr() as *mut u8;
+    // SAFETY: `ptr` points to `len` bytes owned by `cstring`; we have exclusive
+    // access for the duration of this call because we just took ownership.
+    std::ptr::write_bytes(ptr, 0, len);
+    std::sync::atomic::compiler_fence(std::sync::atomic::Ordering::SeqCst);
+
+    drop(cstring);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// `into_secret_cstr` round-trips a mnemonic into a C string and back,
+    /// proving that the helper produces a valid NUL-terminated buffer.
+    #[test]
+    fn into_secret_cstr_round_trip() {
+        let secret = Zeroizing::new("abandon ability able about above absent".to_string());
+        let expected = secret.clone();
+
+        let raw = into_secret_cstr(secret).expect("non-empty secret converts");
+        assert!(!raw.is_null());
+
+        // SAFETY: `raw` was just allocated by `into_secret_cstr` and is owned here.
+        let recovered = unsafe { CStr::from_ptr(raw) }
+            .to_str()
+            .expect("valid UTF-8");
+        assert_eq!(recovered, &*expected);
+
+        // SAFETY: `raw` came from `into_secret_cstr` which uses `CString::into_raw`,
+        // so this is the matching free.
+        unsafe { axiom_recovery_words_free(raw) };
+    }
+
+    /// Calling the free function on a null pointer must be a no-op (matches
+    /// the contract of `axiom_string_free`).
+    #[test]
+    fn recovery_words_free_null_is_noop() {
+        // SAFETY: documented contract — null is allowed and ignored.
+        unsafe { axiom_recovery_words_free(std::ptr::null_mut()) };
+    }
+
+    /// `axiom_recovery_words_free` zeroizes the buffer before releasing it.
+    ///
+    /// Rather than reading freed memory (which is UB), we verify the wipe by
+    /// reimplementing the free logic in safe code: manually reclaim a matching
+    /// `CString`, inspect its bytes to confirm they match the mnemonic, then
+    /// apply the same `write_bytes` + fence sequence that
+    /// `axiom_recovery_words_free` performs and assert the result.
+    ///
+    /// This is a structural check on the primitive used inside the FFI free
+    /// function — it ensures the compiler cannot elide the wipe under the
+    /// compiler_fence and that the byte range covers the full C string
+    /// including the NUL terminator.
+    #[test]
+    fn recovery_words_free_wipes_bytes_before_drop() {
+        let secret = Zeroizing::new("witness witness witness witness".to_string());
+        let raw = into_secret_cstr(secret).expect("conversion succeeds");
+
+        // Take ownership of the allocation back (mirrors the first step in
+        // axiom_recovery_words_free). SAFETY: `raw` came from CString::into_raw.
+        let cstring = unsafe { CString::from_raw(raw) };
+        let bytes_with_nul = cstring.as_bytes_with_nul();
+        assert_eq!(bytes_with_nul[0], b'w');
+        assert!(bytes_with_nul.ends_with(&[0]));
+        let len = bytes_with_nul.len();
+        let ptr = bytes_with_nul.as_ptr() as *mut u8;
+
+        // Apply the same wipe as the FFI free.
+        // SAFETY: exclusive ownership via `cstring`; writing `len` bytes is in-bounds.
+        unsafe { std::ptr::write_bytes(ptr, 0, len) };
+        std::sync::atomic::compiler_fence(std::sync::atomic::Ordering::SeqCst);
+
+        // The buffer is now all zeros while still owned.
+        let after: &[u8] = cstring.as_bytes_with_nul();
+        assert!(after.iter().all(|&b| b == 0), "buffer not fully zeroed");
+
+        // Drop releases the (now-zeroed) allocation.
+        drop(cstring);
     }
 }

--- a/core/ffi/src/lib.rs
+++ b/core/ffi/src/lib.rs
@@ -155,6 +155,7 @@ pub extern "C" fn axiom_version() -> *const c_char {
 /// - `password` must be a valid null-terminated UTF-8 string
 /// - Returns a handle that must be freed with `axiom_vault_close`
 /// - On error, returns null and sets error message retrievable via `axiom_last_error`
+// SAFETY: see `# Safety` rustdoc above; caller upholds raw-pointer invariants.
 #[no_mangle]
 pub unsafe extern "C" fn axiom_vault_create(
     path: *const c_char,
@@ -181,6 +182,7 @@ pub unsafe extern "C" fn axiom_vault_create(
 /// - `path` must be a valid null-terminated UTF-8 string
 /// - `password` must be a valid null-terminated UTF-8 string
 /// - Returns a handle that must be freed with `axiom_vault_close`
+// SAFETY: see `# Safety` rustdoc above; caller upholds raw-pointer invariants.
 #[no_mangle]
 pub unsafe extern "C" fn axiom_vault_open(
     path: *const c_char,
@@ -206,6 +208,7 @@ pub unsafe extern "C" fn axiom_vault_open(
 /// # Safety
 /// - `handle` must be a valid handle returned by `axiom_vault_create` or `axiom_vault_open`
 /// - After this call, the handle is invalid and must not be used
+// SAFETY: see `# Safety` rustdoc above; caller upholds raw-pointer invariants.
 #[no_mangle]
 pub unsafe extern "C" fn axiom_vault_close(handle: *mut FFIVaultHandle) -> c_int {
     if handle.is_null() {
@@ -247,6 +250,7 @@ pub unsafe extern "C" fn axiom_vault_close(handle: *mut FFIVaultHandle) -> c_int
 /// # Safety
 /// - `handle` must be a valid vault handle
 /// - Returns a pointer to `FFIVaultInfo` that must be freed with `axiom_vault_info_free`
+// SAFETY: see `# Safety` rustdoc above; caller upholds raw-pointer invariants.
 #[no_mangle]
 pub unsafe extern "C" fn axiom_vault_info(handle: *const FFIVaultHandle) -> *mut FFIVaultInfo {
     if handle.is_null() {
@@ -267,6 +271,7 @@ pub unsafe extern "C" fn axiom_vault_info(handle: *const FFIVaultHandle) -> *mut
 ///
 /// # Safety
 /// - `info` must be a valid pointer returned by `axiom_vault_info`
+// SAFETY: see `# Safety` rustdoc above; caller upholds raw-pointer invariants.
 #[no_mangle]
 pub unsafe extern "C" fn axiom_vault_info_free(info: *mut FFIVaultInfo) {
     if !info.is_null() {
@@ -291,6 +296,7 @@ pub unsafe extern "C" fn axiom_vault_info_free(info: *mut FFIVaultInfo) {
 /// - `path` must be a valid null-terminated UTF-8 string (use "/" for root)
 /// - Returns a JSON string containing the file list
 /// - Returned string must be freed with `axiom_string_free`
+// SAFETY: see `# Safety` rustdoc above; caller upholds raw-pointer invariants.
 #[no_mangle]
 pub unsafe extern "C" fn axiom_vault_list(
     handle: *const FFIVaultHandle,
@@ -322,6 +328,7 @@ pub unsafe extern "C" fn axiom_vault_list(
 /// - `handle` must be a valid vault handle
 /// - `local_path` must be a valid null-terminated UTF-8 string (path to local file)
 /// - `vault_path` must be a valid null-terminated UTF-8 string (path in vault)
+// SAFETY: see `# Safety` rustdoc above; caller upholds raw-pointer invariants.
 #[no_mangle]
 pub unsafe extern "C" fn axiom_vault_add_file(
     handle: *const FFIVaultHandle,
@@ -353,6 +360,7 @@ pub unsafe extern "C" fn axiom_vault_add_file(
 /// - `handle` must be a valid vault handle
 /// - `vault_path` must be a valid null-terminated UTF-8 string (path in vault)
 /// - `local_path` must be a valid null-terminated UTF-8 string (path to save file)
+// SAFETY: see `# Safety` rustdoc above; caller upholds raw-pointer invariants.
 #[no_mangle]
 pub unsafe extern "C" fn axiom_vault_extract_file(
     handle: *const FFIVaultHandle,
@@ -383,6 +391,7 @@ pub unsafe extern "C" fn axiom_vault_extract_file(
 /// # Safety
 /// - `handle` must be a valid vault handle
 /// - `vault_path` must be a valid null-terminated UTF-8 string
+// SAFETY: see `# Safety` rustdoc above; caller upholds raw-pointer invariants.
 #[no_mangle]
 pub unsafe extern "C" fn axiom_vault_mkdir(
     handle: *const FFIVaultHandle,
@@ -408,6 +417,7 @@ pub unsafe extern "C" fn axiom_vault_mkdir(
 /// # Safety
 /// - `handle` must be a valid vault handle
 /// - `vault_path` must be a valid null-terminated UTF-8 string
+// SAFETY: see `# Safety` rustdoc above; caller upholds raw-pointer invariants.
 #[no_mangle]
 pub unsafe extern "C" fn axiom_vault_remove(
     handle: *const FFIVaultHandle,
@@ -437,6 +447,7 @@ pub unsafe extern "C" fn axiom_vault_remove(
 /// # Safety
 /// - `handle` must be a valid vault handle
 /// - `old_password` and `new_password` must be valid null-terminated UTF-8 strings
+// SAFETY: see `# Safety` rustdoc above; caller upholds raw-pointer invariants.
 #[no_mangle]
 pub unsafe extern "C" fn axiom_vault_change_password(
     handle: *const FFIVaultHandle,
@@ -476,6 +487,7 @@ pub unsafe extern "C" fn axiom_vault_change_password(
 /// - `handle` must be a valid vault handle
 /// - Returned string must be freed with [`axiom_recovery_words_free`]
 ///   (NOT `axiom_string_free` — recovery words require zeroizing free)
+// SAFETY: see `# Safety` rustdoc above; caller upholds raw-pointer invariants.
 #[no_mangle]
 pub unsafe extern "C" fn axiom_vault_get_recovery_words(
     handle: *const FFIVaultHandle,
@@ -512,6 +524,7 @@ pub unsafe extern "C" fn axiom_vault_get_recovery_words(
 /// - `handle` must be a valid vault handle
 /// - Returned string must be freed with [`axiom_recovery_words_free`]
 ///   (NOT `axiom_string_free` — recovery words require zeroizing free)
+// SAFETY: see `# Safety` rustdoc above; caller upholds raw-pointer invariants.
 #[no_mangle]
 pub unsafe extern "C" fn axiom_vault_show_recovery_key(
     handle: *const FFIVaultHandle,
@@ -540,6 +553,7 @@ pub unsafe extern "C" fn axiom_vault_show_recovery_key(
 /// - `recovery_words` must be a valid null-terminated UTF-8 string (24 space-separated words)
 /// - `new_password` must be a valid null-terminated UTF-8 string
 /// - Returns a vault handle on success, null on failure
+// SAFETY: see `# Safety` rustdoc above; caller upholds raw-pointer invariants.
 #[no_mangle]
 pub unsafe extern "C" fn axiom_vault_reset_password(
     path: *const c_char,
@@ -582,6 +596,7 @@ pub unsafe extern "C" fn axiom_vault_reset_password(
 /// - 0: up to date
 /// - 1: needs migration
 /// - -1: incompatible or error (check `axiom_last_error`)
+// SAFETY: see `# Safety` rustdoc above; caller upholds raw-pointer invariants.
 #[no_mangle]
 pub unsafe extern "C" fn axiom_vault_check_migration(path: *const c_char) -> c_int {
     let path_str = match str_from_ptr(path, "path") {
@@ -607,6 +622,7 @@ pub unsafe extern "C" fn axiom_vault_check_migration(path: *const c_char) -> c_i
 /// # Returns
 /// - 0 on success
 /// - -1 on error (check `axiom_last_error`)
+// SAFETY: see `# Safety` rustdoc above; caller upholds raw-pointer invariants.
 #[no_mangle]
 pub unsafe extern "C" fn axiom_vault_migrate(
     path: *const c_char,
@@ -636,6 +652,7 @@ pub unsafe extern "C" fn axiom_vault_migrate(
 /// - `path` must be a valid null-terminated UTF-8 string
 /// - `password` may be null for a shallow (structure-only) check
 /// - Returned string must be freed with `axiom_string_free`
+// SAFETY: see `# Safety` rustdoc above; caller upholds raw-pointer invariants.
 #[no_mangle]
 pub unsafe extern "C" fn axiom_vault_health_check(
     path: *const c_char,
@@ -684,6 +701,7 @@ pub unsafe extern "C" fn axiom_vault_health_check(
 /// - `handle` must be a valid vault handle
 /// - `callback` must be a valid function pointer or null
 /// - The callback may be invoked from any thread
+// SAFETY: see `# Safety` rustdoc above; caller upholds raw-pointer invariants.
 #[no_mangle]
 pub unsafe extern "C" fn axiom_vault_subscribe_events(
     handle: *const FFIVaultHandle,
@@ -773,6 +791,7 @@ pub extern "C" fn axiom_last_error() -> *mut c_char {
 /// # Safety
 /// - `s` must be a valid pointer returned by an axiom FFI function
 /// - After this call, the pointer is invalid
+// SAFETY: see `# Safety` rustdoc above; caller upholds raw-pointer invariants.
 #[no_mangle]
 pub unsafe extern "C" fn axiom_string_free(s: *mut c_char) {
     if !s.is_null() {
@@ -795,6 +814,7 @@ pub unsafe extern "C" fn axiom_string_free(s: *mut c_char) {
 /// - `s` must be a valid pointer returned by `axiom_vault_get_recovery_words`
 ///   or `axiom_vault_show_recovery_key`
 /// - After this call, the pointer is invalid
+// SAFETY: see `# Safety` rustdoc above; caller upholds raw-pointer invariants.
 #[no_mangle]
 pub unsafe extern "C" fn axiom_recovery_words_free(s: *mut c_char) {
     if s.is_null() {
@@ -810,19 +830,23 @@ pub unsafe extern "C" fn axiom_recovery_words_free(s: *mut c_char) {
     // takes back ownership of the same allocation and won't be called twice.
     let cstring = CString::from_raw(s);
 
-    // Overwrite the bytes (including the NUL terminator) in place, through
-    // the pointer we still hold. This uses a volatile-style write via
-    // `write_bytes` plus a compiler fence to prevent the writes being elided
-    // by the optimizer before the subsequent free.
-    let bytes = cstring.as_bytes_with_nul();
+    // Convert into an owned `Vec<u8>` so we can mutate via a legitimate
+    // `as_mut_ptr()`. Writing through a `*mut` derived from `&[u8]` (as the
+    // previous implementation did via `cstring.as_bytes_with_nul().as_ptr()
+    // as *mut u8`) violates Rust's aliasing model: the optimizer is allowed
+    // to assume bytes behind a shared reference are not mutated, and could
+    // elide the wipe entirely — turning this security-critical zeroization
+    // into a no-op. Owning a `Vec` makes the mutation legitimate.
+    let mut bytes = cstring.into_bytes_with_nul();
     let len = bytes.len();
-    let ptr = bytes.as_ptr() as *mut u8;
-    // SAFETY: `ptr` points to `len` bytes owned by `cstring`; we have exclusive
-    // access for the duration of this call because we just took ownership.
+    let ptr = bytes.as_mut_ptr();
+    // SAFETY: `ptr` points to `len` bytes owned by `bytes`; exclusive access
+    // is guaranteed because we own the `Vec`. The compiler_fence prevents the
+    // wipe from being reordered past the subsequent deallocation.
     std::ptr::write_bytes(ptr, 0, len);
     std::sync::atomic::compiler_fence(std::sync::atomic::Ordering::SeqCst);
 
-    drop(cstring);
+    drop(bytes);
 }
 
 #[cfg(test)]
@@ -878,22 +902,24 @@ mod tests {
         // Take ownership of the allocation back (mirrors the first step in
         // axiom_recovery_words_free). SAFETY: `raw` came from CString::into_raw.
         let cstring = unsafe { CString::from_raw(raw) };
-        let bytes_with_nul = cstring.as_bytes_with_nul();
-        assert_eq!(bytes_with_nul[0], b'w');
-        assert!(bytes_with_nul.ends_with(&[0]));
-        let len = bytes_with_nul.len();
-        let ptr = bytes_with_nul.as_ptr() as *mut u8;
+
+        // Convert to an owned `Vec<u8>` so we can mutate legitimately via
+        // `as_mut_ptr()` — same shape as the FFI free.
+        let mut bytes = cstring.into_bytes_with_nul();
+        assert_eq!(bytes[0], b'w');
+        assert!(bytes.ends_with(&[0]));
+        let len = bytes.len();
+        let ptr = bytes.as_mut_ptr();
 
         // Apply the same wipe as the FFI free.
-        // SAFETY: exclusive ownership via `cstring`; writing `len` bytes is in-bounds.
+        // SAFETY: exclusive ownership via `bytes`; writing `len` bytes is in-bounds.
         unsafe { std::ptr::write_bytes(ptr, 0, len) };
         std::sync::atomic::compiler_fence(std::sync::atomic::Ordering::SeqCst);
 
         // The buffer is now all zeros while still owned.
-        let after: &[u8] = cstring.as_bytes_with_nul();
-        assert!(after.iter().all(|&b| b == 0), "buffer not fully zeroed");
+        assert!(bytes.iter().all(|&b| b == 0), "buffer not fully zeroed");
 
         // Drop releases the (now-zeroed) allocation.
-        drop(cstring);
+        drop(bytes);
     }
 }

--- a/core/ffi/src/lib.rs
+++ b/core/ffi/src/lib.rs
@@ -883,13 +883,12 @@ mod tests {
     /// Rather than reading freed memory (which is UB), we verify the wipe by
     /// reimplementing the free logic in safe code: manually reclaim a matching
     /// `CString`, inspect its bytes to confirm they match the mnemonic, then
-    /// apply the same `write_bytes` + fence sequence that
+    /// apply the same `zeroize::Zeroize` primitive that
     /// `axiom_recovery_words_free` performs and assert the result.
     ///
     /// This is a structural check on the primitive used inside the FFI free
-    /// function — it ensures the compiler cannot elide the wipe under the
-    /// compiler_fence and that the byte range covers the full C string
-    /// including the NUL terminator.
+    /// function — it ensures the wipe covers the full C string including the
+    /// NUL terminator.
     #[test]
     fn recovery_words_free_wipes_bytes_before_drop() {
         let secret = Zeroizing::new("witness witness witness witness".to_string());
@@ -904,13 +903,9 @@ mod tests {
         let mut bytes = cstring.into_bytes_with_nul();
         assert_eq!(bytes[0], b'w');
         assert!(bytes.ends_with(&[0]));
-        let len = bytes.len();
-        let ptr = bytes.as_mut_ptr();
-
         // Apply the same wipe as the FFI free.
-        // SAFETY: exclusive ownership via `bytes`; writing `len` bytes is in-bounds.
-        unsafe { std::ptr::write_bytes(ptr, 0, len) };
-        std::sync::atomic::compiler_fence(std::sync::atomic::Ordering::SeqCst);
+        use zeroize::Zeroize;
+        bytes.zeroize();
 
         // The buffer is now all zeros while still owned.
         assert!(bytes.iter().all(|&b| b == 0), "buffer not fully zeroed");

--- a/core/ffi/src/types.rs
+++ b/core/ffi/src/types.rs
@@ -7,6 +7,7 @@ use std::sync::Mutex;
 
 use axiomvault_app::AppService;
 use tokio::task::JoinHandle;
+use zeroize::Zeroizing;
 
 /// Opaque handle to the application service.
 ///
@@ -17,8 +18,10 @@ pub struct FFIVaultHandle {
     /// Vault storage path on disk (for health check / migration).
     pub(crate) path: String,
     /// Recovery words from vault creation. One-time retrievable — cleared after
-    /// the first call to `axiom_vault_get_recovery_words`.
-    pub(crate) recovery_words: Mutex<Option<String>>,
+    /// the first call to `axiom_vault_get_recovery_words`. Wrapped in
+    /// [`Zeroizing`] so the mnemonic bytes are wiped from memory when the
+    /// handle is freed without ever being read.
+    pub(crate) recovery_words: Mutex<Option<Zeroizing<String>>>,
     /// Background task forwarding events to the C callback. At most one
     /// subscription is active at a time — re-subscribing aborts the previous.
     pub(crate) event_task: Mutex<Option<JoinHandle<()>>>,

--- a/core/ffi/src/vault_ops.rs
+++ b/core/ffi/src/vault_ops.rs
@@ -10,6 +10,7 @@ use axiomvault_vault::{
     check_migration_needed, check_vault_health, check_vault_structure, MigrationRegistry,
     MigrationStatus, VaultConfig, VaultManager as CoreVaultManager, VaultVersion,
 };
+use zeroize::Zeroizing;
 
 use crate::error::{FFIError, FFIResult};
 use crate::types::{FFIVaultHandle, FFIVaultInfo};
@@ -28,7 +29,10 @@ fn resolve_path(path: &str) -> FFIResult<String> {
 }
 
 /// Create a new vault at the specified path.
-pub async fn create_vault(path: &str, password: &str) -> FFIResult<FFIVaultHandle> {
+///
+/// `password` is taken by value as [`Zeroizing<String>`] so the secret is
+/// wiped from memory regardless of success or failure.
+pub async fn create_vault(path: &str, password: Zeroizing<String>) -> FFIResult<FFIVaultHandle> {
     let abs_path = resolve_path(path)?;
 
     // Derive vault ID from directory name.
@@ -43,7 +47,7 @@ pub async fn create_vault(path: &str, password: &str) -> FFIResult<FFIVaultHandl
     let result = service
         .create_vault(CreateVaultParams {
             vault_id: vault_name.to_string(),
-            password: password.to_string(),
+            password,
             provider_type: "local".to_string(),
             provider_config,
         })
@@ -53,20 +57,24 @@ pub async fn create_vault(path: &str, password: &str) -> FFIResult<FFIVaultHandl
     Ok(FFIVaultHandle {
         service,
         path: abs_path,
-        recovery_words: std::sync::Mutex::new(Some(String::from(&*result.recovery_words))),
+        // Move the mnemonic into the handle without copying into a non-zeroizing buffer.
+        recovery_words: std::sync::Mutex::new(Some(result.recovery_words)),
         event_task: std::sync::Mutex::new(None),
     })
 }
 
 /// Open an existing vault at the specified path.
-pub async fn open_vault(path: &str, password: &str) -> FFIResult<FFIVaultHandle> {
+///
+/// `password` is taken by value as [`Zeroizing<String>`] so the secret is
+/// wiped from memory regardless of success or failure.
+pub async fn open_vault(path: &str, password: Zeroizing<String>) -> FFIResult<FFIVaultHandle> {
     let abs_path = resolve_path(path)?;
     let provider_config = serde_json::json!({ "root": abs_path });
 
     let service = AppService::new();
     service
         .open_vault(OpenVaultParams {
-            password: password.to_string(),
+            password,
             provider_type: "local".to_string(),
             provider_config,
         })
@@ -173,10 +181,13 @@ pub async fn remove_entry(handle: &FFIVaultHandle, vault_path: &str) -> FFIResul
 }
 
 /// Change the vault password.
+///
+/// Both passwords are taken by value as [`Zeroizing<String>`] so they are
+/// wiped from memory regardless of success or failure.
 pub async fn change_password(
     handle: &FFIVaultHandle,
-    old_password: &str,
-    new_password: &str,
+    old_password: Zeroizing<String>,
+    new_password: Zeroizing<String>,
 ) -> FFIResult<()> {
     handle
         .service
@@ -186,7 +197,10 @@ pub async fn change_password(
 }
 
 /// Show recovery key for an open vault.
-pub async fn show_recovery_key(handle: &FFIVaultHandle) -> FFIResult<String> {
+///
+/// Returns the mnemonic wrapped in [`Zeroizing`] so the bytes are wiped
+/// from memory once the FFI layer has copied them to the C-owned buffer.
+pub async fn show_recovery_key(handle: &FFIVaultHandle) -> FFIResult<Zeroizing<String>> {
     // Recovery key display requires direct session access (not in AppService).
     let session = handle
         .service
@@ -205,15 +219,17 @@ pub async fn show_recovery_key(handle: &FFIVaultHandle) -> FFIResult<String> {
 
     recovery_key
         .to_mnemonic()
-        .map(|z| String::from(&*z))
         .map_err(|e| FFIError::VaultError(e.to_string()))
 }
 
 /// Reset vault password using recovery key words.
+///
+/// Both `recovery_words` and `new_password` are taken by value as
+/// [`Zeroizing<String>`] so they are wiped from memory regardless of outcome.
 pub async fn reset_password(
     path: &str,
-    recovery_words: &str,
-    new_password: &str,
+    recovery_words: Zeroizing<String>,
+    new_password: Zeroizing<String>,
 ) -> FFIResult<FFIVaultHandle> {
     let abs_path = resolve_path(path)?;
     let provider_config = serde_json::json!({ "root": abs_path });
@@ -221,8 +237,8 @@ pub async fn reset_password(
     let service = AppService::new();
     service
         .recover_vault(RecoverVaultParams {
-            recovery_words: recovery_words.to_string(),
-            new_password: new_password.to_string(),
+            recovery_words,
+            new_password,
             provider_type: "local".to_string(),
             provider_config,
         })

--- a/core/fuse/src/filesystem.rs
+++ b/core/fuse/src/filesystem.rs
@@ -39,7 +39,11 @@ fn create_file_attr(ino: INodeNo, is_dir: bool, size: u64) -> FileAttr {
         },
         perm: if is_dir { 0o700 } else { 0o600 },
         nlink: if is_dir { 2 } else { 1 },
+        // SAFETY: `getuid`/`getgid` are async-signal-safe POSIX syscalls with no
+        // preconditions and no side effects; they always return the current
+        // process's UID/GID.
         uid: unsafe { libc::getuid() },
+        // SAFETY: see `getuid` above.
         gid: unsafe { libc::getgid() },
         rdev: 0,
         blksize: 4096,

--- a/core/storage/src/composite/erasure.rs
+++ b/core/storage/src/composite/erasure.rs
@@ -142,6 +142,17 @@ impl CompositeStorageProvider {
             let backend = Arc::clone(&self.backends[i]);
             let shard_path = Self::shard_path(path, i)?;
             // Header: [4-byte LE CRC-32 of shard_data] [8-byte LE original_size] [shard_data]
+            //
+            // SECURITY NOTE: CRC-32 is a NON-CRYPTOGRAPHIC checksum and is
+            // used here ONLY to detect accidental bit rot or transport
+            // corruption of an erasure shard. It does NOT provide
+            // authenticity: a backend that rewrites a shard can trivially
+            // recompute and replace the CRC. Authenticity / tamper-detection
+            // is provided one layer up by the AEAD (XChaCha20-Poly1305) at
+            // the vault layer — any malicious modification of plaintext or
+            // ciphertext is caught when the AEAD tag fails to verify. CRC
+            // mismatches here just let us treat a shard as missing and
+            // reconstruct it from the remaining Reed-Solomon shards.
             let crc = crc32fast::hash(&shard);
             let mut payload = Vec::with_capacity(4 + 8 + shard.len());
             payload.extend_from_slice(&crc.to_le_bytes());

--- a/core/storage/src/dropbox/client.rs
+++ b/core/storage/src/dropbox/client.rs
@@ -113,7 +113,9 @@ impl DropboxClient {
             }
         }
         if status == StatusCode::UNAUTHORIZED {
-            return Error::Authentication("Dropbox authentication failed".to_string());
+            // Transient: token rejected, likely expired. Let the retry
+            // executor trigger a refresh on the next attempt.
+            return Error::AuthenticationExpired("Dropbox authentication failed".to_string());
         }
         Error::Storage(format!("Dropbox API error ({}): {}", status, body))
     }

--- a/core/storage/src/dropbox/client.rs
+++ b/core/storage/src/dropbox/client.rs
@@ -78,7 +78,10 @@ pub struct UploadSessionStart {
 
 /// Dropbox API client.
 pub struct DropboxClient {
+    /// HTTP client for streaming uploads and downloads (no total timeout).
     http: Client,
+    /// HTTP client for short metadata requests (bounded total timeout).
+    metadata_http: Client,
     token_manager: Arc<DropboxTokenManager>,
 }
 
@@ -87,6 +90,7 @@ impl DropboxClient {
     pub fn new(token_manager: Arc<DropboxTokenManager>) -> axiomvault_common::Result<Self> {
         Ok(Self {
             http: http_client::build_http_client()?,
+            metadata_http: http_client::build_metadata_http_client()?,
             token_manager,
         })
     }
@@ -118,7 +122,7 @@ impl DropboxClient {
     pub async fn get_metadata(&self, path: &str) -> Result<DropboxMetadata> {
         let auth = self.auth_header().await?;
         let resp = self
-            .http
+            .metadata_http
             .post(format!("{}/files/get_metadata", API_BASE))
             .header(header::AUTHORIZATION, &auth)
             .header(header::CONTENT_TYPE, "application/json")
@@ -149,7 +153,7 @@ impl DropboxClient {
         let list_path = if path == "/" { "" } else { path };
 
         let resp = self
-            .http
+            .metadata_http
             .post(format!("{}/files/list_folder", API_BASE))
             .header(header::AUTHORIZATION, &auth)
             .header(header::CONTENT_TYPE, "application/json")
@@ -182,7 +186,7 @@ impl DropboxClient {
         while result.has_more {
             let auth = self.auth_header().await?;
             let resp = self
-                .http
+                .metadata_http
                 .post(format!("{}/files/list_folder/continue", API_BASE))
                 .header(header::AUTHORIZATION, &auth)
                 .header(header::CONTENT_TYPE, "application/json")
@@ -432,7 +436,7 @@ impl DropboxClient {
     pub async fn delete(&self, path: &str) -> Result<()> {
         let auth = self.auth_header().await?;
         let resp = self
-            .http
+            .metadata_http
             .post(format!("{}/files/delete_v2", API_BASE))
             .header(header::AUTHORIZATION, &auth)
             .header(header::CONTENT_TYPE, "application/json")
@@ -457,7 +461,7 @@ impl DropboxClient {
     pub async fn create_folder(&self, path: &str) -> Result<DropboxMetadata> {
         let auth = self.auth_header().await?;
         let resp = self
-            .http
+            .metadata_http
             .post(format!("{}/files/create_folder_v2", API_BASE))
             .header(header::AUTHORIZATION, &auth)
             .header(header::CONTENT_TYPE, "application/json")
@@ -496,7 +500,7 @@ impl DropboxClient {
     pub async fn move_entry(&self, from_path: &str, to_path: &str) -> Result<DropboxMetadata> {
         let auth = self.auth_header().await?;
         let resp = self
-            .http
+            .metadata_http
             .post(format!("{}/files/move_v2", API_BASE))
             .header(header::AUTHORIZATION, &auth)
             .header(header::CONTENT_TYPE, "application/json")
@@ -535,7 +539,7 @@ impl DropboxClient {
     pub async fn copy_entry(&self, from_path: &str, to_path: &str) -> Result<DropboxMetadata> {
         let auth = self.auth_header().await?;
         let resp = self
-            .http
+            .metadata_http
             .post(format!("{}/files/copy_v2", API_BASE))
             .header(header::AUTHORIZATION, &auth)
             .header(header::CONTENT_TYPE, "application/json")

--- a/core/storage/src/gdrive/client.rs
+++ b/core/storage/src/gdrive/client.rs
@@ -73,7 +73,10 @@ struct FileListResponse {
 
 /// Google Drive API client.
 pub struct DriveClient {
+    /// HTTP client for streaming uploads and downloads (no total timeout).
     http: Client,
+    /// HTTP client for short metadata requests (bounded total timeout).
+    metadata_http: Client,
     token_manager: std::sync::Arc<TokenManager>,
 }
 
@@ -82,6 +85,7 @@ impl DriveClient {
     pub fn new(token_manager: std::sync::Arc<TokenManager>) -> axiomvault_common::Result<Self> {
         Ok(Self {
             http: http_client::build_http_client()?,
+            metadata_http: http_client::build_metadata_http_client()?,
             token_manager,
         })
     }
@@ -122,7 +126,7 @@ impl DriveClient {
         let auth = self.auth_header().await?;
 
         let response = self
-            .http
+            .metadata_http
             .get(&url)
             .header(header::AUTHORIZATION, auth)
             .query(&[(
@@ -151,7 +155,7 @@ impl DriveClient {
         }
 
         let response = self
-            .http
+            .metadata_http
             .post(&url)
             .header(header::AUTHORIZATION, auth)
             .header(header::CONTENT_TYPE, "application/json")
@@ -184,7 +188,7 @@ impl DriveClient {
             );
 
             let mut request = self
-                .http
+                .metadata_http
                 .get(&url)
                 .header(header::AUTHORIZATION, auth)
                 .query(&[
@@ -228,7 +232,7 @@ impl DriveClient {
         );
 
         let response = self
-            .http
+            .metadata_http
             .get(&url)
             .header(header::AUTHORIZATION, auth)
             .query(&[
@@ -339,7 +343,7 @@ impl DriveClient {
         });
 
         let response = self
-            .http
+            .metadata_http
             .post(&url)
             .header(header::AUTHORIZATION, auth)
             .header(header::CONTENT_TYPE, "application/json")
@@ -531,7 +535,7 @@ impl DriveClient {
         let auth = self.auth_header().await?;
 
         let response = self
-            .http
+            .metadata_http
             .delete(&url)
             .header(header::AUTHORIZATION, auth)
             .send()
@@ -567,7 +571,7 @@ impl DriveClient {
         }
 
         let mut request = self
-            .http
+            .metadata_http
             .patch(&url)
             .header(header::AUTHORIZATION, auth)
             .header(header::CONTENT_TYPE, "application/json")
@@ -609,7 +613,7 @@ impl DriveClient {
         });
 
         let response = self
-            .http
+            .metadata_http
             .post(&url)
             .header(header::AUTHORIZATION, auth)
             .header(header::CONTENT_TYPE, "application/json")

--- a/core/storage/src/http_client.rs
+++ b/core/storage/src/http_client.rs
@@ -235,10 +235,16 @@ mod tests {
         // Outer guard must not fire — the bounded client should have
         // returned its own timeout well before 2s elapsed.
         let inner = result.expect("bounded client did not hang past its own timeout");
+        let err = match inner {
+            Err(err) => err,
+            Ok(resp) => panic!(
+                "request should have timed out, got status: {}",
+                resp.status()
+            ),
+        };
         assert!(
-            inner.is_err(),
-            "request should have failed (timeout), got: {:?}",
-            inner.map(|r| r.status())
+            err.is_timeout(),
+            "request should have timed out, got: {err:?}"
         );
     }
 }

--- a/core/storage/src/http_client.rs
+++ b/core/storage/src/http_client.rs
@@ -70,7 +70,7 @@ pub fn bearer_header(token: &str) -> String {
 ///
 /// | Status | Error variant |
 /// |--------|--------------|
-/// | 401    | `Authentication` |
+/// | 401    | `AuthenticationExpired` (transient — token needs refresh) |
 /// | 403    | `NotPermitted` |
 /// | 404    | `NotFound` |
 /// | 409    | `AlreadyExists` |
@@ -79,7 +79,11 @@ pub fn map_status_error(status: StatusCode, body: &str) -> Error {
     if status == StatusCode::NOT_FOUND {
         Error::NotFound(format!("Resource not found: {}", body))
     } else if status == StatusCode::UNAUTHORIZED {
-        Error::Authentication("Invalid or expired token".to_string())
+        // A 401 is the textbook transient auth case: the access token
+        // is no longer accepted, but the refresh token is (probably)
+        // still good. Surface as `AuthenticationExpired` so the retry
+        // executor gives the token manager a chance to refresh.
+        Error::AuthenticationExpired("Invalid or expired token".to_string())
     } else if status == StatusCode::FORBIDDEN {
         Error::NotPermitted("Access denied".to_string())
     } else if status == StatusCode::CONFLICT {
@@ -142,7 +146,7 @@ mod tests {
     #[test]
     fn test_map_status_unauthorized() {
         let err = map_status_error(StatusCode::UNAUTHORIZED, "bad token");
-        assert!(matches!(err, Error::Authentication(_)));
+        assert!(matches!(err, Error::AuthenticationExpired(_)));
     }
 
     #[test]

--- a/core/storage/src/http_client.rs
+++ b/core/storage/src/http_client.rs
@@ -17,15 +17,42 @@ use axiomvault_common::Error;
 /// User-Agent string for all cloud API requests.
 const USER_AGENT: &str = "AxiomVault/0.1";
 
+/// Total request timeout used by [`build_metadata_http_client`].
+///
+/// Metadata calls (small JSON requests) are expected to complete quickly;
+/// 30 seconds is well above normal latency but bounds the impact of a
+/// hung or slow-loris server.
+const METADATA_REQUEST_TIMEOUT: Duration = Duration::from_secs(30);
+
 /// Build an HTTP client with standard settings for cloud API usage.
 ///
 /// Configures a consistent User-Agent header and connection timeout (10s).
-/// No total request timeout is set because cloud providers handle both
-/// small metadata requests and large file transfers through the same client.
+/// No total request timeout is set because this client is also used for
+/// streaming uploads and downloads that may legitimately take many minutes
+/// (large files, slow uplinks). For small metadata calls use
+/// [`build_metadata_http_client`] instead, which adds a bounded
+/// per-request timeout to limit DoS / hang exposure.
 pub fn build_http_client() -> Result<Client, Error> {
     Client::builder()
         .user_agent(USER_AGENT)
         .connect_timeout(Duration::from_secs(10))
+        .build()
+        .map_err(|e| Error::Network(format!("Failed to create HTTP client: {}", e)))
+}
+
+/// Build an HTTP client suitable for short-lived metadata requests.
+///
+/// Identical to [`build_http_client`] but adds a 30-second total request
+/// timeout. Use this client for JSON metadata calls (list, get, delete,
+/// move, copy, create-folder, session-init, etc.) where a hang would
+/// otherwise stall the whole sync indefinitely. Do **not** use it for
+/// streaming uploads or downloads — those need to be unbounded so that
+/// large transfers can complete.
+pub fn build_metadata_http_client() -> Result<Client, Error> {
+    Client::builder()
+        .user_agent(USER_AGENT)
+        .connect_timeout(Duration::from_secs(10))
+        .timeout(METADATA_REQUEST_TIMEOUT)
         .build()
         .map_err(|e| Error::Network(format!("Failed to create HTTP client: {}", e)))
 }
@@ -149,5 +176,56 @@ mod tests {
     fn test_build_http_client() {
         let client = build_http_client();
         assert!(client.is_ok());
+    }
+
+    #[test]
+    fn test_build_metadata_http_client() {
+        let client = build_metadata_http_client();
+        assert!(client.is_ok());
+    }
+
+    /// The bounded metadata client must surface a timeout (rather than
+    /// hang indefinitely) when a server accepts the connection but
+    /// never sends a response. We verify behaviour against a local TCP
+    /// listener that does nothing after `accept()` — `reqwest::Client`
+    /// does not expose its configured timeout, so we exercise it.
+    #[tokio::test]
+    async fn test_metadata_http_client_times_out() {
+        use std::time::Duration;
+        use tokio::net::TcpListener;
+
+        // Bind a local listener and accept-but-never-respond. The
+        // request should resolve as a timeout error within ~200ms.
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        let _accept_task = tokio::spawn(async move {
+            // Accept once and hold the connection open without writing.
+            if let Ok((stream, _)) = listener.accept().await {
+                // Keep the stream alive for the duration of the test.
+                tokio::time::sleep(Duration::from_secs(5)).await;
+                drop(stream);
+            }
+        });
+
+        // Replicate the production builder but with a short timeout so
+        // the test is fast.
+        let client = Client::builder()
+            .user_agent(USER_AGENT)
+            .connect_timeout(Duration::from_secs(10))
+            .timeout(Duration::from_millis(200))
+            .build()
+            .expect("client builds");
+
+        let url = format!("http://{}/", addr);
+        let result = tokio::time::timeout(Duration::from_secs(2), client.get(&url).send()).await;
+
+        // Outer guard must not fire — the bounded client should have
+        // returned its own timeout well before 2s elapsed.
+        let inner = result.expect("bounded client did not hang past its own timeout");
+        assert!(
+            inner.is_err(),
+            "request should have failed (timeout), got: {:?}",
+            inner.map(|r| r.status())
+        );
     }
 }

--- a/core/storage/src/http_client.rs
+++ b/core/storage/src/http_client.rs
@@ -22,7 +22,7 @@ const USER_AGENT: &str = "AxiomVault/0.1";
 /// Metadata calls (small JSON requests) are expected to complete quickly;
 /// 30 seconds is well above normal latency but bounds the impact of a
 /// hung or slow-loris server.
-const METADATA_REQUEST_TIMEOUT: Duration = Duration::from_secs(30);
+pub const METADATA_REQUEST_TIMEOUT: Duration = Duration::from_secs(30);
 
 /// Build an HTTP client with standard settings for cloud API usage.
 ///
@@ -49,10 +49,22 @@ pub fn build_http_client() -> Result<Client, Error> {
 /// streaming uploads or downloads — those need to be unbounded so that
 /// large transfers can complete.
 pub fn build_metadata_http_client() -> Result<Client, Error> {
+    build_metadata_http_client_with_timeout(METADATA_REQUEST_TIMEOUT)
+}
+
+/// Build a metadata HTTP client with a caller-specified total request
+/// timeout.
+///
+/// Same shape as [`build_metadata_http_client`] but takes the total
+/// request timeout as a parameter. Exposed primarily for testability —
+/// production code should prefer the parameterless
+/// [`build_metadata_http_client`], which uses
+/// [`METADATA_REQUEST_TIMEOUT`] as the default.
+pub fn build_metadata_http_client_with_timeout(timeout: Duration) -> Result<Client, Error> {
     Client::builder()
         .user_agent(USER_AGENT)
         .connect_timeout(Duration::from_secs(10))
-        .timeout(METADATA_REQUEST_TIMEOUT)
+        .timeout(timeout)
         .build()
         .map_err(|e| Error::Network(format!("Failed to create HTTP client: {}", e)))
 }
@@ -211,13 +223,10 @@ mod tests {
             }
         });
 
-        // Replicate the production builder but with a short timeout so
-        // the test is fast.
-        let client = Client::builder()
-            .user_agent(USER_AGENT)
-            .connect_timeout(Duration::from_secs(10))
-            .timeout(Duration::from_millis(200))
-            .build()
+        // Exercise the production builder with a short timeout so the
+        // test is fast — this guards the real code path rather than a
+        // hand-rolled replica.
+        let client = build_metadata_http_client_with_timeout(Duration::from_millis(200))
             .expect("client builds");
 
         let url = format!("http://{}/", addr);

--- a/core/storage/src/local.rs
+++ b/core/storage/src/local.rs
@@ -431,7 +431,16 @@ impl StorageProvider for LocalProvider {
             }
             #[cfg(not(unix))]
             {
-                fs::write(&to_path, &data).await?;
+                use tokio::io::AsyncWriteExt;
+                let mut file = fs::File::create(&to_path).await?;
+                if let Err(e) = file.write_all(&data).await {
+                    let _ = std::fs::remove_file(&to_path);
+                    return Err(e.into());
+                }
+                if let Err(e) = file.sync_all().await {
+                    let _ = std::fs::remove_file(&to_path);
+                    return Err(e.into());
+                }
             }
         }
 

--- a/core/storage/src/local.rs
+++ b/core/storage/src/local.rs
@@ -270,14 +270,26 @@ impl StorageProvider for LocalProvider {
             )));
         }
 
-        fs::create_dir(&fs_path).await?;
-
-        // Restrict directory mode so other local users cannot list its
-        // contents (defence-in-depth around vault metadata layout).
+        // On Unix, set the mode atomically at directory creation via
+        // `DirBuilder::mode` instead of `create_dir` followed by
+        // `set_permissions`. The latter leaves a brief window where the
+        // directory exists with umask-affected permissions and another
+        // local user could enter or list it.
         #[cfg(unix)]
         {
-            use std::os::unix::fs::PermissionsExt;
-            fs::set_permissions(&fs_path, std::fs::Permissions::from_mode(DIR_MODE)).await?;
+            use std::os::unix::fs::DirBuilderExt;
+            let fs_path_blocking = fs_path.clone();
+            tokio::task::spawn_blocking(move || {
+                std::fs::DirBuilder::new()
+                    .mode(DIR_MODE)
+                    .create(&fs_path_blocking)
+            })
+            .await
+            .map_err(|e| Error::Storage(format!("spawn_blocking join error: {}", e)))??;
+        }
+        #[cfg(not(unix))]
+        {
+            fs::create_dir(&fs_path).await?;
         }
 
         let fs_meta = fs::metadata(&fs_path).await?;
@@ -342,18 +354,53 @@ impl StorageProvider for LocalProvider {
         }
 
         if from_path.is_dir() {
-            fs::create_dir(&to_path).await?;
+            // Create the destination directory with restrictive mode set
+            // atomically at creation (Unix). Avoids the TOCTOU window where
+            // `create_dir` followed by `set_permissions` would briefly
+            // expose the new directory at the umask-affected mode.
             #[cfg(unix)]
             {
-                use std::os::unix::fs::PermissionsExt;
-                fs::set_permissions(&to_path, std::fs::Permissions::from_mode(DIR_MODE)).await?;
+                use std::os::unix::fs::DirBuilderExt;
+                let to_blocking = to_path.clone();
+                tokio::task::spawn_blocking(move || {
+                    std::fs::DirBuilder::new()
+                        .mode(DIR_MODE)
+                        .create(&to_blocking)
+                })
+                .await
+                .map_err(|e| Error::Storage(format!("spawn_blocking join error: {}", e)))??;
+            }
+            #[cfg(not(unix))]
+            {
+                fs::create_dir(&to_path).await?;
             }
         } else {
-            fs::copy(&from_path, &to_path).await?;
+            // Read source then create destination atomically with restrictive
+            // mode (Unix), mirroring `upload`. `fs::copy` followed by
+            // `set_permissions` would briefly expose the destination at the
+            // umask-affected mode (TOCTOU).
+            let data = fs::read(&from_path).await?;
             #[cfg(unix)]
             {
-                use std::os::unix::fs::PermissionsExt;
-                fs::set_permissions(&to_path, std::fs::Permissions::from_mode(FILE_MODE)).await?;
+                use tokio::io::AsyncWriteExt;
+                let mut file = tokio::fs::OpenOptions::new()
+                    .write(true)
+                    .create_new(true)
+                    .mode(FILE_MODE)
+                    .open(&to_path)
+                    .await?;
+                if let Err(e) = file.write_all(&data).await {
+                    let _ = std::fs::remove_file(&to_path);
+                    return Err(e.into());
+                }
+                if let Err(e) = file.sync_all().await {
+                    let _ = std::fs::remove_file(&to_path);
+                    return Err(e.into());
+                }
+            }
+            #[cfg(not(unix))]
+            {
+                fs::write(&to_path, &data).await?;
             }
         }
 
@@ -435,6 +482,51 @@ mod tests {
 
         let mode = std::fs::metadata(&root).unwrap().permissions().mode() & 0o777;
         assert_eq!(mode, 0o700, "newly created vault root must be owner-only");
+    }
+
+    /// Audit hardening: `copy` of a regular file must produce a destination
+    /// with mode `0o600` from the moment of creation. The pre-fix
+    /// implementation used `fs::copy` then `set_permissions`, leaving a
+    /// TOCTOU window where another local user could open the destination at
+    /// the umask-affected mode.
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn test_local_copy_file_sets_restrictive_file_mode() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let temp = TempDir::new().unwrap();
+        let provider = LocalProvider::new(temp.path()).unwrap();
+        let src = VaultPath::parse("/src.bin").unwrap();
+        let dst = VaultPath::parse("/dst.bin").unwrap();
+        provider.upload(&src, b"ciphertext".to_vec()).await.unwrap();
+        provider.copy(&src, &dst).await.unwrap();
+
+        let fs_path = temp.path().join("dst.bin");
+        let mode = std::fs::metadata(&fs_path).unwrap().permissions().mode() & 0o777;
+        assert_eq!(mode, 0o600, "copied file must be owner-only readable");
+
+        // Content must still match.
+        let copied = provider.download(&dst).await.unwrap();
+        assert_eq!(copied, b"ciphertext");
+    }
+
+    /// Audit hardening: `copy` of a directory must produce a destination
+    /// with mode `0o700` set atomically at creation (no TOCTOU window).
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn test_local_copy_dir_sets_restrictive_dir_mode() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let temp = TempDir::new().unwrap();
+        let provider = LocalProvider::new(temp.path()).unwrap();
+        let src = VaultPath::parse("/srcdir").unwrap();
+        let dst = VaultPath::parse("/dstdir").unwrap();
+        provider.create_dir(&src).await.unwrap();
+        provider.copy(&src, &dst).await.unwrap();
+
+        let fs_path = temp.path().join("dstdir");
+        let mode = std::fs::metadata(&fs_path).unwrap().permissions().mode() & 0o777;
+        assert_eq!(mode, 0o700, "copied directory must be owner-only");
     }
 
     #[tokio::test]

--- a/core/storage/src/local.rs
+++ b/core/storage/src/local.rs
@@ -59,6 +59,24 @@ impl LocalProvider {
             }
         }
 
+        // Defense in depth: if the root already existed (or an adversary
+        // pre-created it in the gap between `exists()` and `create`), we
+        // never applied DIR_MODE. With `recursive(true)`, `create` succeeds
+        // silently against a pre-existing weak-mode directory. Read the
+        // actual mode now and repair it if it differs. This does NOT close
+        // the creation race, but it ensures any adversary's pre-emptive
+        // weak-mode directory gets re-permissioned before we trust it for
+        // wrapped keys / KDF parameters / ciphertext.
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            let meta = std::fs::metadata(&root)?;
+            let current_mode = meta.permissions().mode() & 0o777;
+            if current_mode != DIR_MODE {
+                std::fs::set_permissions(&root, std::fs::Permissions::from_mode(DIR_MODE))?;
+            }
+        }
+
         Ok(Self { root })
     }
 
@@ -153,7 +171,20 @@ impl StorageProvider for LocalProvider {
         }
         #[cfg(not(unix))]
         {
-            fs::write(&tmp_path, &data).await?;
+            // Match the Unix branch's durability semantics: explicit
+            // create -> write_all -> sync_all. `fs::write` skips the
+            // fsync, so on power loss the rename target could resolve to
+            // a zero-length file. Keep both platforms aligned.
+            use tokio::io::AsyncWriteExt;
+            let mut file = fs::File::create(&tmp_path).await?;
+            if let Err(e) = file.write_all(&data).await {
+                let _ = std::fs::remove_file(&tmp_path);
+                return Err(e.into());
+            }
+            if let Err(e) = file.sync_all().await {
+                let _ = std::fs::remove_file(&tmp_path);
+                return Err(e.into());
+            }
         }
 
         if let Err(e) = fs::rename(&tmp_path, &fs_path).await {
@@ -482,6 +513,35 @@ mod tests {
 
         let mode = std::fs::metadata(&root).unwrap().permissions().mode() & 0o777;
         assert_eq!(mode, 0o700, "newly created vault root must be owner-only");
+    }
+
+    /// Defense-in-depth: when the root directory already exists (e.g. an
+    /// adversary pre-created it with a permissive mode in the gap between
+    /// our `exists()` check and our `DirBuilder::create`, or it was just
+    /// left over from a prior run with the wrong mode), `LocalProvider::new`
+    /// must repair the mode to `DIR_MODE` (0o700) before returning.
+    #[cfg(unix)]
+    #[test]
+    fn test_local_new_repairs_pre_existing_root_mode() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let temp = TempDir::new().unwrap();
+        let root = temp.path().join("vault-root");
+
+        // Pre-create the root with a world-readable mode, simulating either
+        // a leftover directory or an adversary winning the TOCTOU race.
+        std::fs::create_dir(&root).unwrap();
+        std::fs::set_permissions(&root, std::fs::Permissions::from_mode(0o755)).unwrap();
+        let pre_mode = std::fs::metadata(&root).unwrap().permissions().mode() & 0o777;
+        assert_eq!(pre_mode, 0o755, "test setup must produce 0o755");
+
+        LocalProvider::new(&root).unwrap();
+
+        let mode = std::fs::metadata(&root).unwrap().permissions().mode() & 0o777;
+        assert_eq!(
+            mode, 0o700,
+            "pre-existing root with weak mode must be repaired to 0o700"
+        );
     }
 
     /// Audit hardening: `copy` of a regular file must produce a destination

--- a/core/storage/src/local.rs
+++ b/core/storage/src/local.rs
@@ -10,6 +10,13 @@ use uuid::Uuid;
 use crate::provider::{ByteStream, Metadata, StorageProvider};
 use axiomvault_common::{Error, Result, VaultPath};
 
+/// File mode for vault files (owner read/write only).
+#[cfg(unix)]
+const FILE_MODE: u32 = 0o600;
+/// Directory mode for vault directories (owner read/write/execute only).
+#[cfg(unix)]
+const DIR_MODE: u32 = 0o700;
+
 /// Local filesystem storage provider.
 ///
 /// Stores vault data in a local directory structure.
@@ -26,6 +33,7 @@ impl LocalProvider {
     /// # Postconditions
     /// - Provider is ready to use
     /// - Root directory is created if it doesn't exist
+    /// - On Unix, a newly created root directory is restricted to mode `0o700`
     ///
     /// # Errors
     /// - Invalid path
@@ -33,9 +41,22 @@ impl LocalProvider {
     pub fn new(root: impl AsRef<Path>) -> Result<Self> {
         let root = root.as_ref().to_path_buf();
 
-        // Create root if it doesn't exist (sync for constructor)
+        // Create root if it doesn't exist (sync for constructor).
+        // On Unix, restrict mode to 0o700 so other local users cannot read
+        // wrapped keys, KDF parameters, or ciphertext sitting at rest.
         if !root.exists() {
-            std::fs::create_dir_all(&root)?;
+            #[cfg(unix)]
+            {
+                use std::os::unix::fs::DirBuilderExt;
+                std::fs::DirBuilder::new()
+                    .recursive(true)
+                    .mode(DIR_MODE)
+                    .create(&root)?;
+            }
+            #[cfg(not(unix))]
+            {
+                std::fs::create_dir_all(&root)?;
+            }
         }
 
         Ok(Self { root })
@@ -103,7 +124,37 @@ impl StorageProvider for LocalProvider {
             uuid::Uuid::new_v4()
         ));
 
-        fs::write(&tmp_path, &data).await?;
+        // Create the temp file with restrictive permissions on Unix so
+        // other local users cannot read ciphertext or vault config that
+        // contains wrapped keys / KDF parameters. On non-Unix targets we
+        // fall back to the default permissions (the file will inherit
+        // platform defaults).
+        #[cfg(unix)]
+        {
+            use tokio::io::AsyncWriteExt;
+
+            // tokio::fs::OpenOptions exposes `mode()` directly on Unix
+            // (cfg-gated to the unix targets), so no extension trait
+            // import is required.
+            let mut file = tokio::fs::OpenOptions::new()
+                .write(true)
+                .create_new(true)
+                .mode(FILE_MODE)
+                .open(&tmp_path)
+                .await?;
+            if let Err(e) = file.write_all(&data).await {
+                let _ = std::fs::remove_file(&tmp_path);
+                return Err(e.into());
+            }
+            if let Err(e) = file.sync_all().await {
+                let _ = std::fs::remove_file(&tmp_path);
+                return Err(e.into());
+            }
+        }
+        #[cfg(not(unix))]
+        {
+            fs::write(&tmp_path, &data).await?;
+        }
 
         if let Err(e) = fs::rename(&tmp_path, &fs_path).await {
             // Best-effort cleanup; ignore secondary error
@@ -221,6 +272,14 @@ impl StorageProvider for LocalProvider {
 
         fs::create_dir(&fs_path).await?;
 
+        // Restrict directory mode so other local users cannot list its
+        // contents (defence-in-depth around vault metadata layout).
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            fs::set_permissions(&fs_path, std::fs::Permissions::from_mode(DIR_MODE)).await?;
+        }
+
         let fs_meta = fs::metadata(&fs_path).await?;
         Ok(self.create_metadata(path, fs_meta))
     }
@@ -284,8 +343,18 @@ impl StorageProvider for LocalProvider {
 
         if from_path.is_dir() {
             fs::create_dir(&to_path).await?;
+            #[cfg(unix)]
+            {
+                use std::os::unix::fs::PermissionsExt;
+                fs::set_permissions(&to_path, std::fs::Permissions::from_mode(DIR_MODE)).await?;
+            }
         } else {
             fs::copy(&from_path, &to_path).await?;
+            #[cfg(unix)]
+            {
+                use std::os::unix::fs::PermissionsExt;
+                fs::set_permissions(&to_path, std::fs::Permissions::from_mode(FILE_MODE)).await?;
+            }
         }
 
         let fs_meta = fs::metadata(&to_path).await?;
@@ -319,6 +388,53 @@ mod tests {
 
         let metadata = provider.create_dir(&path).await.unwrap();
         assert!(metadata.is_directory);
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn test_local_upload_sets_restrictive_file_mode() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let temp = TempDir::new().unwrap();
+        let provider = LocalProvider::new(temp.path()).unwrap();
+        let path = VaultPath::parse("/secret.bin").unwrap();
+        provider
+            .upload(&path, b"ciphertext".to_vec())
+            .await
+            .unwrap();
+
+        let fs_path = temp.path().join("secret.bin");
+        let mode = std::fs::metadata(&fs_path).unwrap().permissions().mode() & 0o777;
+        assert_eq!(mode, 0o600, "uploaded file must be owner-only readable");
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn test_local_create_dir_sets_restrictive_dir_mode() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let temp = TempDir::new().unwrap();
+        let provider = LocalProvider::new(temp.path()).unwrap();
+        let path = VaultPath::parse("/private").unwrap();
+        provider.create_dir(&path).await.unwrap();
+
+        let fs_path = temp.path().join("private");
+        let mode = std::fs::metadata(&fs_path).unwrap().permissions().mode() & 0o777;
+        assert_eq!(mode, 0o700, "created directory must be owner-only");
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn test_local_new_creates_root_with_restrictive_dir_mode() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let temp = TempDir::new().unwrap();
+        let root = temp.path().join("vault-root");
+        assert!(!root.exists());
+        LocalProvider::new(&root).unwrap();
+
+        let mode = std::fs::metadata(&root).unwrap().permissions().mode() & 0o777;
+        assert_eq!(mode, 0o700, "newly created vault root must be owner-only");
     }
 
     #[tokio::test]

--- a/core/storage/src/local.rs
+++ b/core/storage/src/local.rs
@@ -149,6 +149,7 @@ impl StorageProvider for LocalProvider {
         // platform defaults).
         #[cfg(unix)]
         {
+            use std::os::unix::fs::PermissionsExt;
             use tokio::io::AsyncWriteExt;
 
             // tokio::fs::OpenOptions exposes `mode()` directly on Unix
@@ -159,6 +160,8 @@ impl StorageProvider for LocalProvider {
                 .create_new(true)
                 .mode(FILE_MODE)
                 .open(&tmp_path)
+                .await?;
+            tokio::fs::set_permissions(&tmp_path, std::fs::Permissions::from_mode(FILE_MODE))
                 .await?;
             if let Err(e) = file.write_all(&data).await {
                 let _ = std::fs::remove_file(&tmp_path);
@@ -308,12 +311,16 @@ impl StorageProvider for LocalProvider {
         // local user could enter or list it.
         #[cfg(unix)]
         {
-            use std::os::unix::fs::DirBuilderExt;
+            use std::os::unix::fs::{DirBuilderExt, PermissionsExt};
             let fs_path_blocking = fs_path.clone();
             tokio::task::spawn_blocking(move || {
                 std::fs::DirBuilder::new()
                     .mode(DIR_MODE)
-                    .create(&fs_path_blocking)
+                    .create(&fs_path_blocking)?;
+                std::fs::set_permissions(
+                    &fs_path_blocking,
+                    std::fs::Permissions::from_mode(DIR_MODE),
+                )
             })
             .await
             .map_err(|e| Error::Storage(format!("spawn_blocking join error: {}", e)))??;
@@ -391,12 +398,16 @@ impl StorageProvider for LocalProvider {
             // expose the new directory at the umask-affected mode.
             #[cfg(unix)]
             {
-                use std::os::unix::fs::DirBuilderExt;
+                use std::os::unix::fs::{DirBuilderExt, PermissionsExt};
                 let to_blocking = to_path.clone();
                 tokio::task::spawn_blocking(move || {
                     std::fs::DirBuilder::new()
                         .mode(DIR_MODE)
-                        .create(&to_blocking)
+                        .create(&to_blocking)?;
+                    std::fs::set_permissions(
+                        &to_blocking,
+                        std::fs::Permissions::from_mode(DIR_MODE),
+                    )
                 })
                 .await
                 .map_err(|e| Error::Storage(format!("spawn_blocking join error: {}", e)))??;
@@ -406,38 +417,40 @@ impl StorageProvider for LocalProvider {
                 fs::create_dir(&to_path).await?;
             }
         } else {
-            // Read source then create destination atomically with restrictive
-            // mode (Unix), mirroring `upload`. `fs::copy` followed by
-            // `set_permissions` would briefly expose the destination at the
-            // umask-affected mode (TOCTOU).
-            let data = fs::read(&from_path).await?;
+            // Stream the source into a freshly-created destination instead of
+            // loading the whole vault object into memory. The Unix path keeps
+            // restrictive creation mode and then repairs exact bits in case a
+            // restrictive umask removed owner permissions.
             #[cfg(unix)]
             {
-                use tokio::io::AsyncWriteExt;
-                let mut file = tokio::fs::OpenOptions::new()
+                use std::os::unix::fs::PermissionsExt;
+                let mut source = fs::File::open(&from_path).await?;
+                let mut destination = tokio::fs::OpenOptions::new()
                     .write(true)
                     .create_new(true)
                     .mode(FILE_MODE)
                     .open(&to_path)
                     .await?;
-                if let Err(e) = file.write_all(&data).await {
+                tokio::fs::set_permissions(&to_path, std::fs::Permissions::from_mode(FILE_MODE))
+                    .await?;
+                if let Err(e) = tokio::io::copy(&mut source, &mut destination).await {
                     let _ = std::fs::remove_file(&to_path);
                     return Err(e.into());
                 }
-                if let Err(e) = file.sync_all().await {
+                if let Err(e) = destination.sync_all().await {
                     let _ = std::fs::remove_file(&to_path);
                     return Err(e.into());
                 }
             }
             #[cfg(not(unix))]
             {
-                use tokio::io::AsyncWriteExt;
-                let mut file = fs::File::create(&to_path).await?;
-                if let Err(e) = file.write_all(&data).await {
+                let mut source = fs::File::open(&from_path).await?;
+                let mut destination = fs::File::create_new(&to_path).await?;
+                if let Err(e) = tokio::io::copy(&mut source, &mut destination).await {
                     let _ = std::fs::remove_file(&to_path);
                     return Err(e.into());
                 }
-                if let Err(e) = file.sync_all().await {
+                if let Err(e) = destination.sync_all().await {
                     let _ = std::fs::remove_file(&to_path);
                     return Err(e.into());
                 }

--- a/core/storage/src/onedrive/client.rs
+++ b/core/storage/src/onedrive/client.rs
@@ -118,7 +118,10 @@ struct UploadSession {
 
 /// Microsoft Graph API client for OneDrive.
 pub struct OneDriveClient {
+    /// HTTP client for streaming uploads and downloads (no total timeout).
     http: Client,
+    /// HTTP client for short metadata requests (bounded total timeout).
+    metadata_http: Client,
     token_manager: Arc<OneDriveTokenManager>,
 }
 
@@ -127,6 +130,7 @@ impl OneDriveClient {
     pub fn new(token_manager: Arc<OneDriveTokenManager>) -> axiomvault_common::Result<Self> {
         Ok(Self {
             http: http_client::build_http_client()?,
+            metadata_http: http_client::build_metadata_http_client()?,
             token_manager,
         })
     }
@@ -171,7 +175,7 @@ impl OneDriveClient {
         let auth = self.auth_header().await?;
 
         let response = self
-            .http
+            .metadata_http
             .get(&url)
             .header(header::AUTHORIZATION, auth)
             .send()
@@ -197,7 +201,7 @@ impl OneDriveClient {
             let auth = self.auth_header().await?;
 
             let response = self
-                .http
+                .metadata_http
                 .get(&url)
                 .header(header::AUTHORIZATION, auth)
                 .send()
@@ -244,7 +248,7 @@ impl OneDriveClient {
         });
 
         let response = self
-            .http
+            .metadata_http
             .post(&url)
             .header(header::AUTHORIZATION, auth)
             .header(header::CONTENT_TYPE, "application/json")
@@ -350,7 +354,7 @@ impl OneDriveClient {
         let auth = self.auth_header().await?;
 
         let response = self
-            .http
+            .metadata_http
             .delete(&url)
             .header(header::AUTHORIZATION, auth)
             .send()
@@ -381,7 +385,7 @@ impl OneDriveClient {
         });
 
         let response = self
-            .http
+            .metadata_http
             .post(&url)
             .header(header::AUTHORIZATION, auth)
             .header(header::CONTENT_TYPE, "application/json")
@@ -416,7 +420,7 @@ impl OneDriveClient {
         });
 
         let response = self
-            .http
+            .metadata_http
             .patch(&url)
             .header(header::AUTHORIZATION, auth)
             .header(header::CONTENT_TYPE, "application/json")
@@ -451,7 +455,7 @@ impl OneDriveClient {
         });
 
         let response = self
-            .http
+            .metadata_http
             .post(&url)
             .header(header::AUTHORIZATION, auth)
             .header(header::CONTENT_TYPE, "application/json")

--- a/core/sync/src/conflict.rs
+++ b/core/sync/src/conflict.rs
@@ -114,16 +114,30 @@ impl ConflictResolver {
         local_etag.is_some() && remote_etag.is_some() && local_etag != remote_etag
     }
 
-    /// Generate a conflict-renamed path (e.g., "file.txt" -> "file_conflict_20240115_123456.txt").
+    /// Generate a conflict-renamed path
+    /// (e.g., "file.txt" -> "file_conflict_20240115_123456_123456_a1b2.txt").
+    ///
+    /// The suffix combines a microsecond-resolution timestamp and a 4-char
+    /// random hex tag so two conflicts on the same path within the same
+    /// wall-clock second cannot collide (audit M-6,
+    /// SECURITY_AUDIT_2026-04-21.md).
     pub fn generate_conflict_path(&self, original: &VaultPath) -> Result<VaultPath> {
+        use rand::RngExt;
+
         let original_str = original.to_string();
-        let timestamp = Utc::now().format("%Y%m%d_%H%M%S").to_string();
+        // %6f -> microseconds (6-digit fractional seconds).
+        let timestamp = Utc::now().format("%Y%m%d_%H%M%S_%6f").to_string();
+
+        // 16 random bits rendered as 4 lowercase hex chars.
+        let mut rand_bytes = [0u8; 2];
+        rand::rng().fill(&mut rand_bytes[..]);
+        let rand_suffix = format!("{:02x}{:02x}", rand_bytes[0], rand_bytes[1]);
 
         let new_path = if let Some(dot_pos) = original_str.rfind('.') {
             let (name, ext) = original_str.split_at(dot_pos);
-            format!("{}_conflict_{}{}", name, timestamp, ext)
+            format!("{}_conflict_{}_{}{}", name, timestamp, rand_suffix, ext)
         } else {
-            format!("{}_conflict_{}", original_str, timestamp)
+            format!("{}_conflict_{}_{}", original_str, timestamp, rand_suffix)
         };
 
         VaultPath::parse(&new_path)
@@ -233,5 +247,77 @@ mod tests {
         let path_str = conflict_path.to_string();
         assert!(path_str.contains("_conflict_"));
         assert!(path_str.starts_with("/docs/README_conflict_"));
+    }
+
+    /// Audit M-6: conflict paths must include a sub-second component and a
+    /// random suffix so same-second collisions are astronomically unlikely.
+    /// Format we expect (for `/docs/report.pdf`):
+    ///   /docs/report_conflict_YYYYMMDD_HHMMSS_uuuuuu_xxxx.pdf
+    ///   - YYYYMMDD     : 8 digits
+    ///   - HHMMSS       : 6 digits
+    ///   - uuuuuu       : 6 digits microseconds
+    ///   - xxxx         : 4 lowercase hex chars
+    #[test]
+    fn test_generate_conflict_path_format_includes_random_suffix() {
+        let resolver = ConflictResolver::default();
+        let original = VaultPath::parse("/docs/report.pdf").unwrap();
+        let conflict_path = resolver.generate_conflict_path(&original).unwrap();
+        let path_str = conflict_path.to_string();
+
+        // Strip the deterministic prefix and suffix.
+        let stem = path_str
+            .strip_prefix("/docs/report_conflict_")
+            .expect("conflict path should start with the original stem prefix");
+        let stem = stem
+            .strip_suffix(".pdf")
+            .expect("conflict path should preserve the original extension");
+
+        // Now `stem` should look like: 20240115_123456_123456_a1b2
+        // i.e. 8 + 1 + 6 + 1 + 6 + 1 + 4 = 27 chars.
+        assert_eq!(
+            stem.len(),
+            27,
+            "conflict path stem `{}` has unexpected length",
+            stem
+        );
+
+        let parts: Vec<&str> = stem.split('_').collect();
+        assert_eq!(
+            parts.len(),
+            4,
+            "conflict path stem `{}` must have 4 underscore-separated parts",
+            stem
+        );
+
+        // Date YYYYMMDD
+        assert_eq!(parts[0].len(), 8);
+        assert!(parts[0].chars().all(|c| c.is_ascii_digit()));
+        // Time HHMMSS
+        assert_eq!(parts[1].len(), 6);
+        assert!(parts[1].chars().all(|c| c.is_ascii_digit()));
+        // Microseconds (6 digits)
+        assert_eq!(parts[2].len(), 6);
+        assert!(parts[2].chars().all(|c| c.is_ascii_digit()));
+        // Random hex suffix (4 lowercase hex chars)
+        assert_eq!(parts[3].len(), 4);
+        assert!(parts[3]
+            .chars()
+            .all(|c| c.is_ascii_hexdigit() && (c.is_ascii_digit() || c.is_ascii_lowercase())));
+    }
+
+    /// Audit M-6: two conflict paths generated back-to-back must differ even
+    /// when the wall-clock second is identical (the random suffix and the
+    /// microseconds together make a collision astronomically unlikely).
+    #[test]
+    fn test_generate_conflict_path_unique_within_same_second() {
+        let resolver = ConflictResolver::default();
+        let original = VaultPath::parse("/file.txt").unwrap();
+
+        let mut seen = std::collections::HashSet::new();
+        for _ in 0..32 {
+            let p = resolver.generate_conflict_path(&original).unwrap();
+            let inserted = seen.insert(p.to_string());
+            assert!(inserted, "duplicate conflict path generated back-to-back");
+        }
     }
 }

--- a/core/sync/src/conflict.rs
+++ b/core/sync/src/conflict.rs
@@ -117,7 +117,7 @@ impl ConflictResolver {
     /// Generate a conflict-renamed path
     /// (e.g., "file.txt" -> "file_conflict_20240115_123456_123456_a1b2.txt").
     ///
-    /// The suffix combines a microsecond-resolution timestamp and a 4-char
+    /// The suffix combines a microsecond-resolution timestamp and a 16-char
     /// random hex tag so two conflicts on the same path within the same
     /// wall-clock second cannot collide (audit M-6,
     /// SECURITY_AUDIT_2026-04-21.md).
@@ -136,17 +136,27 @@ impl ConflictResolver {
             now.timestamp_subsec_micros()
         );
 
-        // 16 random bits rendered as 4 lowercase hex chars.
-        let mut rand_bytes = [0u8; 2];
+        // 64 random bits rendered as 16 lowercase hex chars.
+        let mut rand_bytes = [0u8; 8];
         rand::rng().fill(&mut rand_bytes[..]);
-        let rand_suffix = format!("{:02x}{:02x}", rand_bytes[0], rand_bytes[1]);
+        let mut rand_suffix = String::with_capacity(rand_bytes.len() * 2);
+        for byte in rand_bytes {
+            use std::fmt::Write as _;
+            let _ = write!(&mut rand_suffix, "{byte:02x}");
+        }
 
-        let new_path = if let Some(dot_pos) = original_str.rfind('.') {
-            let (name, ext) = original_str.split_at(dot_pos);
-            format!("{}_conflict_{}_{}{}", name, timestamp, rand_suffix, ext)
-        } else {
-            format!("{}_conflict_{}_{}", original_str, timestamp, rand_suffix)
+        let (parent, file_name) = match original_str.rsplit_once('/') {
+            Some((dir, file_name)) => (format!("{dir}/"), file_name),
+            None => (String::new(), original_str.as_str()),
         };
+
+        let renamed_file = if let Some(dot_pos) = file_name.rfind('.').filter(|&pos| pos > 0) {
+            let (name, ext) = file_name.split_at(dot_pos);
+            format!("{name}_conflict_{timestamp}_{rand_suffix}{ext}")
+        } else {
+            format!("{file_name}_conflict_{timestamp}_{rand_suffix}")
+        };
+        let new_path = format!("{parent}{renamed_file}");
 
         VaultPath::parse(&new_path)
     }
@@ -257,14 +267,40 @@ mod tests {
         assert!(path_str.starts_with("/docs/README_conflict_"));
     }
 
+    #[test]
+    fn test_generate_conflict_path_only_splits_final_component_extension() {
+        let resolver = ConflictResolver::default();
+        let original = VaultPath::parse("/docs.v1/report").unwrap();
+        let conflict_path = resolver.generate_conflict_path(&original).unwrap();
+
+        let path_str = conflict_path.to_string();
+        assert!(
+            path_str.starts_with("/docs.v1/report_conflict_"),
+            "conflict path should rename only final component, got {path_str}"
+        );
+    }
+
+    #[test]
+    fn test_generate_conflict_path_preserves_dotfile_stem() {
+        let resolver = ConflictResolver::default();
+        let original = VaultPath::parse("/docs/.env").unwrap();
+        let conflict_path = resolver.generate_conflict_path(&original).unwrap();
+
+        let path_str = conflict_path.to_string();
+        assert!(
+            path_str.starts_with("/docs/.env_conflict_"),
+            "dotfile should be treated as a filename without extension, got {path_str}"
+        );
+    }
+
     /// Audit M-6: conflict paths must include a sub-second component and a
     /// random suffix so same-second collisions are astronomically unlikely.
     /// Format we expect (for `/docs/report.pdf`):
-    ///   /docs/report_conflict_YYYYMMDD_HHMMSS_uuuuuu_xxxx.pdf
+    ///   /docs/report_conflict_YYYYMMDD_HHMMSS_uuuuuu_xxxxxxxxxxxxxxxx.pdf
     ///   - YYYYMMDD     : 8 digits
     ///   - HHMMSS       : 6 digits
     ///   - uuuuuu       : 6 digits microseconds
-    ///   - xxxx         : 4 lowercase hex chars
+    ///   - xxxxxxxxxxxxxxxx : 16 lowercase hex chars
     #[test]
     fn test_generate_conflict_path_format_includes_random_suffix() {
         let resolver = ConflictResolver::default();
@@ -280,11 +316,11 @@ mod tests {
             .strip_suffix(".pdf")
             .expect("conflict path should preserve the original extension");
 
-        // Now `stem` should look like: 20240115_123456_123456_a1b2
-        // i.e. 8 + 1 + 6 + 1 + 6 + 1 + 4 = 27 chars.
+        // Now `stem` should look like: 20240115_123456_123456_a1b2c3d4e5f60708
+        // i.e. 8 + 1 + 6 + 1 + 6 + 1 + 16 = 39 chars.
         assert_eq!(
             stem.len(),
-            27,
+            39,
             "conflict path stem `{}` has unexpected length",
             stem
         );
@@ -306,8 +342,8 @@ mod tests {
         // Microseconds (6 digits)
         assert_eq!(parts[2].len(), 6);
         assert!(parts[2].chars().all(|c| c.is_ascii_digit()));
-        // Random hex suffix (4 lowercase hex chars)
-        assert_eq!(parts[3].len(), 4);
+        // Random hex suffix (16 lowercase hex chars)
+        assert_eq!(parts[3].len(), 16);
         assert!(parts[3]
             .chars()
             .all(|c| c.is_ascii_hexdigit() && (c.is_ascii_digit() || c.is_ascii_lowercase())));
@@ -330,7 +366,7 @@ mod tests {
     }
 
     /// Audit M-6 regression lock: the generated path must match the exact
-    /// shape `_conflict_\d{8}_\d{6}_\d{6}_[0-9a-f]{4}` (with extension
+    /// shape `_conflict_\d{8}_\d{6}_\d{6}_[0-9a-f]{16}` (with extension
     /// preserved). This guards against a recurrence of the chrono `%6f`
     /// width-vs-microsecond confusion that produced a 0-length microsecond
     /// segment.
@@ -341,17 +377,17 @@ mod tests {
         let conflict_path = resolver.generate_conflict_path(&original).unwrap();
         let path_str = conflict_path.to_string();
 
-        // Hand-rolled regex match for `_conflict_\d{8}_\d{6}_\d{6}_[0-9a-f]{4}`
+        // Hand-rolled regex match for `_conflict_\d{8}_\d{6}_\d{6}_[0-9a-f]{16}`
         // anchored to "/docs/report" + suffix + ".pdf".
         let suffix = path_str
             .strip_prefix("/docs/report")
             .and_then(|s| s.strip_suffix(".pdf"))
             .expect("conflict path must preserve stem and extension");
-        // suffix should be: _conflict_YYYYMMDD_HHMMSS_uuuuuu_xxxx
-        // i.e. "_conflict_" (10) + 8 + 1 + 6 + 1 + 6 + 1 + 4 = 37 chars.
+        // suffix should be: _conflict_YYYYMMDD_HHMMSS_uuuuuu_xxxxxxxxxxxxxxxx
+        // i.e. "_conflict_" (10) + 8 + 1 + 6 + 1 + 6 + 1 + 16 = 49 chars.
         assert_eq!(
             suffix.len(),
-            37,
+            49,
             "suffix `{}` has unexpected length",
             suffix
         );
@@ -375,8 +411,8 @@ mod tests {
             assert!(chars.next().unwrap().is_ascii_digit());
         }
         assert_eq!(chars.next(), Some('_'));
-        // 4 lowercase hex chars
-        for _ in 0..4 {
+        // 16 lowercase hex chars
+        for _ in 0..16 {
             let c = chars.next().unwrap();
             assert!(c.is_ascii_digit() || ('a'..='f').contains(&c));
         }

--- a/core/sync/src/conflict.rs
+++ b/core/sync/src/conflict.rs
@@ -125,8 +125,16 @@ impl ConflictResolver {
         use rand::RngExt;
 
         let original_str = original.to_string();
-        // %6f -> microseconds (6-digit fractional seconds).
-        let timestamp = Utc::now().format("%Y%m%d_%H%M%S_%6f").to_string();
+        // chrono's `%6f` is a *width* directive for nanoseconds — it does NOT
+        // emit fractional seconds on its own. Build the microseconds suffix
+        // explicitly so two conflicts in the same wall-clock second still
+        // differ in the timestamp portion (audit M-6).
+        let now = Utc::now();
+        let timestamp = format!(
+            "{}_{:06}",
+            now.format("%Y%m%d_%H%M%S"),
+            now.timestamp_subsec_micros()
+        );
 
         // 16 random bits rendered as 4 lowercase hex chars.
         let mut rand_bytes = [0u8; 2];
@@ -319,5 +327,59 @@ mod tests {
             let inserted = seen.insert(p.to_string());
             assert!(inserted, "duplicate conflict path generated back-to-back");
         }
+    }
+
+    /// Audit M-6 regression lock: the generated path must match the exact
+    /// shape `_conflict_\d{8}_\d{6}_\d{6}_[0-9a-f]{4}` (with extension
+    /// preserved). This guards against a recurrence of the chrono `%6f`
+    /// width-vs-microsecond confusion that produced a 0-length microsecond
+    /// segment.
+    #[test]
+    fn test_generate_conflict_path_matches_documented_regex() {
+        let resolver = ConflictResolver::default();
+        let original = VaultPath::parse("/docs/report.pdf").unwrap();
+        let conflict_path = resolver.generate_conflict_path(&original).unwrap();
+        let path_str = conflict_path.to_string();
+
+        // Hand-rolled regex match for `_conflict_\d{8}_\d{6}_\d{6}_[0-9a-f]{4}`
+        // anchored to "/docs/report" + suffix + ".pdf".
+        let suffix = path_str
+            .strip_prefix("/docs/report")
+            .and_then(|s| s.strip_suffix(".pdf"))
+            .expect("conflict path must preserve stem and extension");
+        // suffix should be: _conflict_YYYYMMDD_HHMMSS_uuuuuu_xxxx
+        // i.e. "_conflict_" (10) + 8 + 1 + 6 + 1 + 6 + 1 + 4 = 37 chars.
+        assert_eq!(
+            suffix.len(),
+            37,
+            "suffix `{}` has unexpected length",
+            suffix
+        );
+
+        let mut chars = suffix.chars();
+        for c in "_conflict_".chars() {
+            assert_eq!(chars.next(), Some(c));
+        }
+        // 8-digit date
+        for _ in 0..8 {
+            assert!(chars.next().unwrap().is_ascii_digit());
+        }
+        assert_eq!(chars.next(), Some('_'));
+        // 6-digit time
+        for _ in 0..6 {
+            assert!(chars.next().unwrap().is_ascii_digit());
+        }
+        assert_eq!(chars.next(), Some('_'));
+        // 6-digit microseconds (this is the bit that the %6f bug zeroed out)
+        for _ in 0..6 {
+            assert!(chars.next().unwrap().is_ascii_digit());
+        }
+        assert_eq!(chars.next(), Some('_'));
+        // 4 lowercase hex chars
+        for _ in 0..4 {
+            let c = chars.next().unwrap();
+            assert!(c.is_ascii_digit() || ('a'..='f').contains(&c));
+        }
+        assert!(chars.next().is_none());
     }
 }

--- a/core/sync/src/engine.rs
+++ b/core/sync/src/engine.rs
@@ -167,6 +167,7 @@ impl<P: StorageProvider + ?Sized + 'static> SyncEngine<P> {
         let mut files_synced = 0;
         let mut files_failed = 0;
         let mut conflicts_found = 0;
+        let mut pending_persistence = 0;
 
         info!("Starting full sync");
 
@@ -189,6 +190,7 @@ impl<P: StorageProvider + ?Sized + 'static> SyncEngine<P> {
         let download_result = self.download_remote_changes().await;
         files_synced += download_result.0;
         files_failed += download_result.1;
+        pending_persistence += download_result.2;
 
         {
             let mut state = self.state.write().await;
@@ -198,14 +200,15 @@ impl<P: StorageProvider + ?Sized + 'static> SyncEngine<P> {
 
         let duration = start.elapsed();
         info!(
-            "Full sync completed in {:?}: {} synced, {} failed, {} conflicts",
-            duration, files_synced, files_failed, conflicts_found
+            "Full sync completed in {:?}: {} synced, {} failed, {} conflicts, {} pending persistence",
+            duration, files_synced, files_failed, conflicts_found, pending_persistence
         );
 
         Ok(SyncResult {
             files_synced,
             files_failed,
             conflicts_found,
+            pending_persistence,
             duration,
         })
     }
@@ -249,6 +252,7 @@ impl<P: StorageProvider + ?Sized + 'static> SyncEngine<P> {
             files_synced,
             files_failed,
             conflicts_found,
+            pending_persistence: 0,
             duration,
         })
     }
@@ -262,6 +266,7 @@ impl<P: StorageProvider + ?Sized + 'static> SyncEngine<P> {
                 files_synced: 0,
                 files_failed: 0,
                 conflicts_found: 0,
+                pending_persistence: 0,
                 duration: Duration::from_secs(0),
             }),
         }
@@ -482,10 +487,27 @@ impl<P: StorageProvider + ?Sized + 'static> SyncEngine<P> {
         Ok(conflicts)
     }
 
+    // TODO(audit H-1, SECURITY_AUDIT_2026-04-21.md): the sync engine has no
+    // wired-up local destination for downloaded ciphertext. Until a local
+    // provider / staging callback / `VaultOperations::update_file` integration
+    // lands, `download_remote_changes` MUST NOT pretend the data was
+    // persisted: that would silently lose remote-side changes while
+    // reporting success in the sync result counters. The fix here is
+    // intentionally narrow — we only make the failure honest (warn log,
+    // pending_persistence counter, no etag/timestamp mutation). The full
+    // architectural fix is tracked separately.
     /// Download remote changes to local.
-    async fn download_remote_changes(&self) -> (usize, usize) {
-        let mut synced = 0;
+    ///
+    /// Currently, downloaded data has no destination wired up in the engine,
+    /// so successful downloads are reported via `pending_persistence` rather
+    /// than `synced`, and the entry's sync state is left untouched so the
+    /// next sync will see the remote change again.
+    async fn download_remote_changes(&self) -> (usize, usize, usize) {
+        // `synced` stays 0 until persistence is wired up (audit H-1). Successful
+        // downloads are accounted for in `pending_persistence` instead.
+        let synced: usize = 0;
         let mut failed = 0;
+        let mut pending_persistence = 0;
 
         let entries: Vec<(String, SyncStatus)> = {
             let state = self.state.read().await;
@@ -518,27 +540,17 @@ impl<P: StorageProvider + ?Sized + 'static> SyncEngine<P> {
                 .await;
 
             match download_result {
-                Ok(_data) => {
-                    // In a real implementation, we would write this to the vault
-                    // For now, just update the state
-                    let provider = self.provider.clone();
-                    let path_clone = path.clone();
-
-                    if let Ok(metadata) = self
-                        .retry_executor
-                        .execute(move || {
-                            let p = provider.clone();
-                            let path = path_clone.clone();
-                            async move { p.metadata(&path).await }
-                        })
-                        .await
-                    {
-                        let mut state = self.state.write().await;
-                        if let Some(entry) = state.get_mut(&path) {
-                            entry.mark_synced(metadata.etag, metadata.modified);
-                        }
-                    }
-                    synced += 1;
+                Ok(data) => {
+                    // The downloaded ciphertext has nowhere to go yet (audit
+                    // H-1). Surface this honestly: increment the
+                    // pending_persistence counter, leave the entry's sync
+                    // state untouched, and warn so operators can see it.
+                    warn!(
+                        "downloaded {} bytes for path {} but persistence is not yet wired up — entry not marked synced (audit H-1)",
+                        data.len(),
+                        path
+                    );
+                    pending_persistence += 1;
                 }
                 Err(e) => {
                     error!("Failed to download remote file: {}", e);
@@ -547,7 +559,7 @@ impl<P: StorageProvider + ?Sized + 'static> SyncEngine<P> {
             }
         }
 
-        (synced, failed)
+        (synced, failed, pending_persistence)
     }
 
     /// Sync a single path.
@@ -690,6 +702,81 @@ struct SingleSyncResult {
 
 #[cfg(test)]
 mod tests {
-    // Tests would require a mock StorageProvider
-    // See integration tests for full testing
+    use super::*;
+    use axiomvault_storage::MemoryProvider;
+    use tempfile::TempDir;
+
+    /// Audit H-1: a successful remote download must NOT increment the
+    /// `synced` counter and must NOT update the entry's etag/timestamp,
+    /// because the engine has no wired-up local destination yet. It must
+    /// surface the download via the `pending_persistence` counter (and a
+    /// `warn!` log — verifiable by running `cargo test -- --nocapture`).
+    #[tokio::test]
+    async fn test_download_remote_changes_does_not_falsely_mark_synced() {
+        let provider = MemoryProvider::new();
+        let path = VaultPath::parse("/remote-only.bin").unwrap();
+        // Seed remote with a file the engine will "discover" as RemoteModified.
+        provider
+            .upload(&path, b"remote-ciphertext".to_vec())
+            .await
+            .unwrap();
+        let original_remote_meta = provider.metadata(&path).await.unwrap();
+
+        let staging_dir = TempDir::new().unwrap();
+        let engine = SyncEngine::new(provider, staging_dir.path(), SyncConfig::default())
+            .await
+            .unwrap();
+
+        // Pre-seed sync state with an entry whose status is RemoteModified
+        // so download_remote_changes will pick it up. Capture the
+        // pre-download etag so we can assert it doesn't get bumped.
+        let pre_download_local_etag = Some("baseline-local-etag".to_string());
+        let pre_download_remote_etag = Some("baseline-remote-etag".to_string());
+        {
+            let mut state = engine.state.write().await;
+            let mut entry = SyncEntry::new_synced(
+                path.to_string(),
+                pre_download_local_etag.clone(),
+                chrono::Utc::now(),
+            );
+            // Force RemoteModified so download_remote_changes finds it.
+            entry.status = SyncStatus::RemoteModified;
+            entry.remote_etag = pre_download_remote_etag.clone();
+            state.insert(entry);
+        }
+
+        let (synced, failed, pending) = engine.download_remote_changes().await;
+
+        // The honest-failure contract from H-1: synced stays 0, no failure
+        // (the download succeeded), pending bumps.
+        assert_eq!(synced, 0, "synced must not increment without persistence");
+        assert_eq!(failed, 0, "download succeeded so failed must stay 0");
+        assert_eq!(
+            pending, 1,
+            "the successful download must show up in pending"
+        );
+
+        // The entry's etags / status must NOT have been touched (no
+        // silent "this is in sync now" claim).
+        let state = engine.state.read().await;
+        let entry = state.get(&path).expect("entry is still present");
+        assert_eq!(
+            entry.local_etag, pre_download_local_etag,
+            "local_etag must not have been mutated by a no-op download"
+        );
+        assert_eq!(
+            entry.remote_etag, pre_download_remote_etag,
+            "remote_etag must not have been mutated by a no-op download"
+        );
+        assert_eq!(
+            entry.status,
+            SyncStatus::RemoteModified,
+            "status must remain RemoteModified so the next sync sees it again"
+        );
+
+        // Sanity: the remote provider still has the original metadata —
+        // we never touched it.
+        let post_remote_meta = engine.provider.metadata(&path).await.unwrap();
+        assert_eq!(post_remote_meta.etag, original_remote_meta.etag);
+    }
 }

--- a/core/sync/src/retry.rs
+++ b/core/sync/src/retry.rs
@@ -161,17 +161,27 @@ impl RetryExecutor {
     ///
     /// Currently retried:
     /// - `Network` and `Io`: classic transient failures.
-    /// - `Authentication`: an expired OAuth token surfaces as `Authentication`.
-    ///   The underlying `CloudTokenManager` refreshes proactively (5-minute
-    ///   buffer) so this is rarely seen, but if the buffer window is missed
-    ///   (e.g. wall-clock drift, slow scheduler tick) the retry gives the
-    ///   token manager a chance to refresh on the next attempt instead of
-    ///   surfacing a hard failure to the caller. See audit finding L-8
-    ///   (SECURITY_AUDIT_2026-04-21.md).
+    /// - `AuthenticationExpired`: the server rejected the access token
+    ///   (typically HTTP 401) but the refresh token is still believed to
+    ///   be good. The `CloudTokenManager` refreshes proactively (5-minute
+    ///   buffer), so this is rarely seen — but if the buffer window is
+    ///   missed (wall-clock drift, slow scheduler tick) the retry gives
+    ///   the token manager a chance to refresh on the next attempt
+    ///   instead of surfacing a hard failure to the caller. See audit
+    ///   finding L-8 (SECURITY_AUDIT_2026-04-21.md).
+    ///
+    /// Deliberately NOT retried:
+    /// - `Authentication`: reserved for permanent auth failures — invalid
+    ///   credentials, revoked tokens, failed refresh-token redemption,
+    ///   failed OAuth code exchange. Retrying these wastes the budget and
+    ///   can trigger rate-limiting from the provider. The split between
+    ///   `Authentication` (permanent) and `AuthenticationExpired`
+    ///   (transient) replaces the earlier blanket-retry on all auth
+    ///   errors.
     fn is_retryable(&self, err: &Error) -> bool {
         matches!(
             err,
-            Error::Network(_) | Error::Io(_) | Error::Authentication(_)
+            Error::Network(_) | Error::Io(_) | Error::AuthenticationExpired(_)
         )
     }
 
@@ -346,10 +356,11 @@ mod tests {
         assert_eq!(result.unwrap(), "success");
     }
 
-    /// Audit L-8: an `Authentication` error must trigger a retry so the
-    /// underlying token manager has a chance to refresh on the next attempt.
+    /// Audit L-8: an `AuthenticationExpired` error must trigger a retry
+    /// so the underlying token manager has a chance to refresh on the
+    /// next attempt.
     #[tokio::test]
-    async fn test_retry_on_authentication_error() {
+    async fn test_retry_on_authentication_expired() {
         let attempt_count = Arc::new(AtomicU32::new(0));
         let count_clone = attempt_count.clone();
 
@@ -364,7 +375,7 @@ mod tests {
                 async move {
                     let current = count.fetch_add(1, Ordering::SeqCst);
                     if current < 1 {
-                        Err(Error::Authentication("token expired".to_string()))
+                        Err(Error::AuthenticationExpired("token expired".to_string()))
                     } else {
                         Ok(7)
                     }
@@ -373,7 +384,34 @@ mod tests {
             .await;
 
         assert_eq!(result.unwrap(), 7);
-        // First attempt failed with Authentication, second succeeded.
+        // First attempt failed with AuthenticationExpired, second succeeded.
         assert_eq!(attempt_count.load(Ordering::SeqCst), 2);
+    }
+
+    /// Permanent `Authentication` failures (invalid credentials, revoked
+    /// tokens, failed refresh) must NOT be retried: the token manager
+    /// cannot recover, and retrying wastes budget and risks
+    /// rate-limiting.
+    #[tokio::test]
+    async fn test_does_not_retry_permanent_authentication() {
+        let attempt_count = Arc::new(AtomicU32::new(0));
+        let count_clone = attempt_count.clone();
+
+        let config = RetryConfig::new(3).with_initial_delay(Duration::from_millis(1));
+        let executor = RetryExecutor::new(config);
+
+        let result: Result<i32> = executor
+            .execute(move || {
+                let count = count_clone.clone();
+                async move {
+                    count.fetch_add(1, Ordering::SeqCst);
+                    Err(Error::Authentication("invalid credentials".to_string()))
+                }
+            })
+            .await;
+
+        assert!(result.is_err());
+        // Permanent Authentication is not retryable: exactly one attempt.
+        assert_eq!(attempt_count.load(Ordering::SeqCst), 1);
     }
 }

--- a/core/sync/src/retry.rs
+++ b/core/sync/src/retry.rs
@@ -158,8 +158,21 @@ impl RetryExecutor {
     }
 
     /// Check if an error is retryable.
+    ///
+    /// Currently retried:
+    /// - `Network` and `Io`: classic transient failures.
+    /// - `Authentication`: an expired OAuth token surfaces as `Authentication`.
+    ///   The underlying `CloudTokenManager` refreshes proactively (5-minute
+    ///   buffer) so this is rarely seen, but if the buffer window is missed
+    ///   (e.g. wall-clock drift, slow scheduler tick) the retry gives the
+    ///   token manager a chance to refresh on the next attempt instead of
+    ///   surfacing a hard failure to the caller. See audit finding L-8
+    ///   (SECURITY_AUDIT_2026-04-21.md).
     fn is_retryable(&self, err: &Error) -> bool {
-        matches!(err, Error::Network(_) | Error::Io(_))
+        matches!(
+            err,
+            Error::Network(_) | Error::Io(_) | Error::Authentication(_)
+        )
     }
 
     /// Get the retry configuration.
@@ -331,5 +344,36 @@ mod tests {
     async fn test_convenience_retry_function() {
         let result: Result<String> = retry(|| async { Ok("success".to_string()) }).await;
         assert_eq!(result.unwrap(), "success");
+    }
+
+    /// Audit L-8: an `Authentication` error must trigger a retry so the
+    /// underlying token manager has a chance to refresh on the next attempt.
+    #[tokio::test]
+    async fn test_retry_on_authentication_error() {
+        let attempt_count = Arc::new(AtomicU32::new(0));
+        let count_clone = attempt_count.clone();
+
+        let config = RetryConfig::new(3)
+            .with_initial_delay(Duration::from_millis(1))
+            .with_jitter(false);
+        let executor = RetryExecutor::new(config);
+
+        let result: Result<i32> = executor
+            .execute(move || {
+                let count = count_clone.clone();
+                async move {
+                    let current = count.fetch_add(1, Ordering::SeqCst);
+                    if current < 1 {
+                        Err(Error::Authentication("token expired".to_string()))
+                    } else {
+                        Ok(7)
+                    }
+                }
+            })
+            .await;
+
+        assert_eq!(result.unwrap(), 7);
+        // First attempt failed with Authentication, second succeeded.
+        assert_eq!(attempt_count.load(Ordering::SeqCst), 2);
     }
 }

--- a/core/sync/src/scheduler.rs
+++ b/core/sync/src/scheduler.rs
@@ -34,11 +34,18 @@ pub enum SyncRequest {
 }
 
 /// Sync result from the engine.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Default)]
 pub struct SyncResult {
     pub files_synced: usize,
     pub files_failed: usize,
     pub conflicts_found: usize,
+    /// Number of remote downloads that succeeded but could not be persisted
+    /// locally because the engine has no wired-up local destination yet.
+    /// See `download_remote_changes` in `engine.rs` and audit finding H-1
+    /// (SECURITY_AUDIT_2026-04-21.md). This counter is reported separately
+    /// from `files_synced` to avoid silently masquerading dropped data as
+    /// success.
+    pub pending_persistence: usize,
     pub duration: Duration,
 }
 
@@ -309,6 +316,7 @@ mod tests {
                             files_synced: 1,
                             files_failed: 0,
                             conflicts_found: 0,
+                            pending_persistence: 0,
                             duration: Duration::from_millis(100),
                         })
                     }

--- a/core/sync/src/scheduler.rs
+++ b/core/sync/src/scheduler.rs
@@ -195,10 +195,11 @@ impl SyncSchedulerHandle {
                                 match &result {
                                     Ok(sync_result) => {
                                         info!(
-                                            "Periodic sync completed: {} synced, {} failed, {} conflicts",
+                                            "Periodic sync completed: {} synced, {} failed, {} conflicts, {} pending persistence",
                                             sync_result.files_synced,
                                             sync_result.files_failed,
-                                            sync_result.conflicts_found
+                                            sync_result.conflicts_found,
+                                            sync_result.pending_persistence
                                         );
                                     }
                                     Err(e) => {

--- a/core/sync/src/staging.rs
+++ b/core/sync/src/staging.rs
@@ -137,7 +137,16 @@ impl StagingArea {
             match serde_json::from_str::<HashMap<String, StagedChange>>(&content) {
                 Ok(map) => map,
                 Err(e) => {
-                    let ts = Utc::now().format("%Y%m%d_%H%M%S_%6f").to_string();
+                    // chrono's `%6f` is a width directive for nanoseconds and
+                    // does not emit fractional seconds on its own; build the
+                    // microsecond suffix explicitly so renames within the same
+                    // second still differ (audit M-6).
+                    let now = Utc::now();
+                    let ts = format!(
+                        "{}_{:06}",
+                        now.format("%Y%m%d_%H%M%S"),
+                        now.timestamp_subsec_micros()
+                    );
                     let corrupt_path = registry_path
                         .with_file_name(format!("staging_registry.json.corrupt-{}", ts));
                     warn!(
@@ -534,5 +543,56 @@ mod tests {
             found_corrupt_sibling,
             "expected a `staging_registry.json.corrupt-*` sibling preserving the bad file"
         );
+    }
+
+    /// Audit M-6 regression lock: the `corrupt-*` suffix on the renamed
+    /// registry must include a 6-digit microsecond segment, not the 0-length
+    /// segment chrono's misused `%6f` width directive produced.
+    /// Shape: `staging_registry.json.corrupt-\d{8}_\d{6}_\d{6}`.
+    #[tokio::test]
+    async fn test_corrupt_registry_rename_suffix_has_microseconds() {
+        let temp = TempDir::new().unwrap();
+        let registry_path = temp.path().join("staging_registry.json");
+        tokio::fs::write(&registry_path, b"{ broken").await.unwrap();
+
+        let _staging = StagingArea::new(temp.path()).await.unwrap();
+
+        let mut suffix: Option<String> = None;
+        let mut entries = tokio::fs::read_dir(temp.path()).await.unwrap();
+        while let Some(entry) = entries.next_entry().await.unwrap() {
+            let name = entry.file_name();
+            let name_str = name.to_string_lossy().to_string();
+            if let Some(s) = name_str.strip_prefix("staging_registry.json.corrupt-") {
+                suffix = Some(s.to_string());
+                break;
+            }
+        }
+        let suffix = suffix.expect("corrupt sibling must exist");
+
+        // Must be exactly YYYYMMDD_HHMMSS_uuuuuu = 8+1+6+1+6 = 22 chars.
+        assert_eq!(
+            suffix.len(),
+            22,
+            "corrupt suffix `{}` has unexpected length (chrono %6f bug?)",
+            suffix
+        );
+        let parts: Vec<&str> = suffix.split('_').collect();
+        assert_eq!(
+            parts.len(),
+            3,
+            "suffix must be 3 underscore-separated parts"
+        );
+        assert_eq!(parts[0].len(), 8);
+        assert!(parts[0].chars().all(|c| c.is_ascii_digit()));
+        assert_eq!(parts[1].len(), 6);
+        assert!(parts[1].chars().all(|c| c.is_ascii_digit()));
+        // The microsecond segment was 0-length under the %6f bug — assert
+        // it is the full 6 digits.
+        assert_eq!(
+            parts[2].len(),
+            6,
+            "microsecond segment has wrong length (chrono %6f bug?)"
+        );
+        assert!(parts[2].chars().all(|c| c.is_ascii_digit()));
     }
 }

--- a/core/sync/src/staging.rs
+++ b/core/sync/src/staging.rs
@@ -1,13 +1,64 @@
 //! Local staging area for atomic writes.
+//!
+//! # Layering contract — MUST READ
+//!
+//! The bytes passed to [`StagingArea::stage_upload`] **MUST be ciphertext**.
+//! This layer is *not* encrypted at rest: it holds whatever the caller
+//! hands it on the local filesystem, with `0600` (file) and `0700`
+//! (directory) permissions on Unix as defense-in-depth, but those modes
+//! do not protect against a same-user attacker (compromised process,
+//! malicious app on a phone) reading the staging tree directly.
+//!
+//! Concretely: the vault MUST encrypt before staging; `stage_upload` is
+//! not allowed to see plaintext. See audit finding M-5 in
+//! `docs/SECURITY_AUDIT_2026-04-21.md`.
 
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 use tokio::fs;
+use tracing::warn;
 use uuid::Uuid;
 
 use axiomvault_common::{Error, Result, VaultPath};
+
+/// Open `path` for writing with `0o600` permissions on Unix, fail if it
+/// already exists. On non-Unix this falls back to a plain create-new write.
+///
+/// We use `create_new(true)` so a stale file with looser permissions cannot
+/// be reused — the open will fail and the caller can recover.
+async fn write_private_file(path: &Path, data: &[u8]) -> std::io::Result<()> {
+    #[cfg(unix)]
+    {
+        // Note: `tokio::fs::OpenOptions::mode` is inherent on Unix — no
+        // `std::os::unix::fs::OpenOptionsExt` import required.
+        use tokio::io::AsyncWriteExt;
+
+        let mut file = tokio::fs::OpenOptions::new()
+            .write(true)
+            .create_new(true)
+            .mode(0o600)
+            .open(path)
+            .await?;
+        file.write_all(data).await?;
+        file.flush().await?;
+        Ok(())
+    }
+
+    #[cfg(not(unix))]
+    {
+        use tokio::io::AsyncWriteExt;
+        let mut file = tokio::fs::OpenOptions::new()
+            .write(true)
+            .create_new(true)
+            .open(path)
+            .await?;
+        file.write_all(data).await?;
+        file.flush().await?;
+        Ok(())
+    }
+}
 
 /// A staged change waiting to be committed.
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -49,20 +100,63 @@ pub struct StagingArea {
 
 impl StagingArea {
     /// Create a new staging area.
+    ///
+    /// On Unix the staging directory is chmod'd to `0o700` so other local
+    /// users cannot enumerate or read pending changes (audit M-5).
+    ///
+    /// If the on-disk registry exists but is corrupt (invalid JSON), the
+    /// corrupt file is renamed to `staging_registry.json.corrupt-{ts}` so
+    /// the operator can inspect it later, and a fresh empty registry is
+    /// started instead of silently dropping all in-flight changes (audit
+    /// L-7).
     pub async fn new(base_dir: impl AsRef<Path>) -> Result<Self> {
         let base_dir = base_dir.as_ref().to_path_buf();
         let staging_dir = base_dir.join("staging");
         let registry_path = base_dir.join("staging_registry.json");
 
-        // Create staging directory
+        // Create staging directory.
         fs::create_dir_all(&staging_dir).await.map_err(Error::Io)?;
 
-        // Load existing registry if present
+        // Tighten directory permissions on Unix (audit M-5).
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            let perms = std::fs::Permissions::from_mode(0o700);
+            fs::set_permissions(&staging_dir, perms)
+                .await
+                .map_err(Error::Io)?;
+        }
+
+        // Load existing registry if present. Corrupt JSON is preserved on
+        // disk (renamed) so it can be inspected, and we start fresh —
+        // never silently drop in-flight changes (audit L-7).
         let changes = if registry_path.exists() {
             let content = fs::read_to_string(&registry_path)
                 .await
                 .map_err(Error::Io)?;
-            serde_json::from_str(&content).unwrap_or_default()
+            match serde_json::from_str::<HashMap<String, StagedChange>>(&content) {
+                Ok(map) => map,
+                Err(e) => {
+                    let ts = Utc::now().format("%Y%m%d_%H%M%S_%6f").to_string();
+                    let corrupt_path = registry_path
+                        .with_file_name(format!("staging_registry.json.corrupt-{}", ts));
+                    warn!(
+                        "staging registry at {} is corrupt ({}); preserving as {} and starting a fresh registry (audit L-7)",
+                        registry_path.display(),
+                        e,
+                        corrupt_path.display()
+                    );
+                    if let Err(rename_err) = fs::rename(&registry_path, &corrupt_path).await {
+                        warn!(
+                            "failed to rename corrupt staging registry {} -> {}: {}",
+                            registry_path.display(),
+                            corrupt_path.display(),
+                            rename_err
+                        );
+                    }
+                    HashMap::new()
+                }
+            }
         } else {
             HashMap::new()
         };
@@ -75,6 +169,9 @@ impl StagingArea {
     }
 
     /// Stage data for upload.
+    ///
+    /// **Contract:** `data` MUST be ciphertext. See the module-level docs
+    /// (audit M-5).
     pub async fn stage_upload(
         &mut self,
         vault_path: &VaultPath,
@@ -84,8 +181,10 @@ impl StagingArea {
         let change_id = Uuid::new_v4().to_string();
         let staging_file = self.base_dir.join(&change_id);
 
-        // Write data to staging file
-        fs::write(&staging_file, &data).await.map_err(Error::Io)?;
+        // Write data to staging file with mode 0o600 on Unix (audit M-5).
+        write_private_file(&staging_file, &data)
+            .await
+            .map_err(Error::Io)?;
 
         let change = StagedChange {
             id: change_id.clone(),
@@ -202,12 +301,29 @@ impl StagingArea {
     }
 
     /// Persist the registry to disk atomically (write-to-temp + rename).
+    ///
+    /// On Unix the temp file is created with mode `0o600` so the registry
+    /// (which contains pending change metadata: paths, sizes, change types)
+    /// is not world-readable (audit M-5). A leftover temp file from a
+    /// previous crashed write is removed first so `create_new` succeeds.
     async fn persist_registry(&self) -> Result<()> {
         let json = serde_json::to_string_pretty(&self.changes)
             .map_err(|e| Error::Serialization(e.to_string()))?;
 
         let tmp_path = self.registry_path.with_extension("json.tmp");
-        fs::write(&tmp_path, json).await.map_err(Error::Io)?;
+        if tmp_path.exists() {
+            // Best-effort cleanup of a stale temp from a prior crashed write.
+            if let Err(e) = fs::remove_file(&tmp_path).await {
+                warn!(
+                    "failed to remove stale staging registry temp {}: {}",
+                    tmp_path.display(),
+                    e
+                );
+            }
+        }
+        write_private_file(&tmp_path, json.as_bytes())
+            .await
+            .map_err(Error::Io)?;
         fs::rename(&tmp_path, &self.registry_path)
             .await
             .map_err(Error::Io)
@@ -317,5 +433,106 @@ mod tests {
             let staging = StagingArea::new(temp.path()).await.unwrap();
             assert_eq!(staging.count(), 1);
         }
+    }
+
+    /// Audit M-5: staged files (and the registry) must be `0o600` on Unix
+    /// so other local users cannot read pending ciphertext or metadata.
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn test_staged_file_is_mode_0600_on_unix() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let temp = TempDir::new().unwrap();
+        let mut staging = StagingArea::new(temp.path()).await.unwrap();
+
+        let path = VaultPath::parse("/secret.bin").unwrap();
+        let change_id = staging
+            .stage_upload(&path, b"ciphertext".to_vec(), ChangeType::Create)
+            .await
+            .unwrap();
+
+        // The staging file lives under <temp>/staging/<change_id>.
+        let staged_file = temp.path().join("staging").join(&change_id);
+        let file_meta = std::fs::metadata(&staged_file).expect("staged file exists");
+        let file_mode = file_meta.permissions().mode() & 0o777;
+        assert_eq!(
+            file_mode, 0o600,
+            "staged file mode is {:o}, want 0o600",
+            file_mode
+        );
+
+        // The registry file should also be 0o600 (it contains pending
+        // change metadata).
+        let registry_file = temp.path().join("staging_registry.json");
+        let reg_meta = std::fs::metadata(&registry_file).expect("registry file exists");
+        let reg_mode = reg_meta.permissions().mode() & 0o777;
+        assert_eq!(
+            reg_mode, 0o600,
+            "registry file mode is {:o}, want 0o600",
+            reg_mode
+        );
+
+        // The staging directory itself should be 0o700.
+        let dir_meta = std::fs::metadata(temp.path().join("staging")).expect("staging dir exists");
+        let dir_mode = dir_meta.permissions().mode() & 0o777;
+        assert_eq!(
+            dir_mode, 0o700,
+            "staging dir mode is {:o}, want 0o700",
+            dir_mode
+        );
+    }
+
+    /// Audit L-7: when the on-disk registry is corrupt JSON, `StagingArea::new`
+    /// must rename the corrupt file aside (so the operator can inspect it)
+    /// and start with a fresh empty registry — never silently drop the bad
+    /// file.
+    #[tokio::test]
+    async fn test_corrupt_registry_is_renamed_and_fresh_starts() {
+        let temp = TempDir::new().unwrap();
+        let registry_path = temp.path().join("staging_registry.json");
+
+        // Plant a corrupt registry file before construction.
+        tokio::fs::write(&registry_path, b"{ this is not valid json")
+            .await
+            .unwrap();
+
+        let staging = StagingArea::new(temp.path()).await.unwrap();
+        // Fresh empty registry.
+        assert_eq!(staging.count(), 0);
+        // The corrupt file must NOT still be at the original path with the
+        // bad bytes — it must have been renamed aside (or, if rename
+        // failed, the warn was logged; we don't assert that here).
+        if registry_path.exists() {
+            // If a fresh registry has been written since (e.g. by a later
+            // persist_registry call), it must now be valid JSON. We
+            // haven't done any mutating ops, so the file should not exist
+            // at all OR should be valid JSON.
+            let content = tokio::fs::read_to_string(&registry_path).await.unwrap();
+            assert!(
+                serde_json::from_str::<HashMap<String, StagedChange>>(&content).is_ok(),
+                "registry at original path must be valid JSON or absent"
+            );
+        }
+
+        // A `staging_registry.json.corrupt-*` sibling should exist.
+        let mut found_corrupt_sibling = false;
+        let mut entries = tokio::fs::read_dir(temp.path()).await.unwrap();
+        while let Some(entry) = entries.next_entry().await.unwrap() {
+            let name = entry.file_name();
+            let name_str = name.to_string_lossy();
+            if name_str.starts_with("staging_registry.json.corrupt-") {
+                found_corrupt_sibling = true;
+                let content = tokio::fs::read(entry.path()).await.unwrap();
+                assert_eq!(
+                    content, b"{ this is not valid json",
+                    "corrupt sibling should preserve original bytes"
+                );
+                break;
+            }
+        }
+        assert!(
+            found_corrupt_sibling,
+            "expected a `staging_registry.json.corrupt-*` sibling preserving the bad file"
+        );
     }
 }

--- a/core/sync/src/staging.rs
+++ b/core/sync/src/staging.rs
@@ -147,22 +147,27 @@ impl StagingArea {
                         now.format("%Y%m%d_%H%M%S"),
                         now.timestamp_subsec_micros()
                     );
-                    let corrupt_path = registry_path
-                        .with_file_name(format!("staging_registry.json.corrupt-{}", ts));
+                    use rand::RngExt;
+                    let mut rand_bytes = [0u8; 8];
+                    rand::rng().fill(&mut rand_bytes[..]);
+                    let mut rand_suffix = String::with_capacity(rand_bytes.len() * 2);
+                    for byte in rand_bytes {
+                        use std::fmt::Write as _;
+                        let _ = write!(&mut rand_suffix, "{byte:02x}");
+                    }
+                    let corrupt_path = registry_path.with_file_name(format!(
+                        "staging_registry.json.corrupt-{}-{}",
+                        ts, rand_suffix
+                    ));
                     warn!(
                         "staging registry at {} is corrupt ({}); preserving as {} and starting a fresh registry (audit L-7)",
                         registry_path.display(),
                         e,
                         corrupt_path.display()
                     );
-                    if let Err(rename_err) = fs::rename(&registry_path, &corrupt_path).await {
-                        warn!(
-                            "failed to rename corrupt staging registry {} -> {}: {}",
-                            registry_path.display(),
-                            corrupt_path.display(),
-                            rename_err
-                        );
-                    }
+                    fs::rename(&registry_path, &corrupt_path)
+                        .await
+                        .map_err(Error::Io)?;
                     HashMap::new()
                 }
             }
@@ -548,7 +553,7 @@ mod tests {
     /// Audit M-6 regression lock: the `corrupt-*` suffix on the renamed
     /// registry must include a 6-digit microsecond segment, not the 0-length
     /// segment chrono's misused `%6f` width directive produced.
-    /// Shape: `staging_registry.json.corrupt-\d{8}_\d{6}_\d{6}`.
+    /// Shape: `staging_registry.json.corrupt-\d{8}_\d{6}_\d{6}-[0-9a-f]{16}`.
     #[tokio::test]
     async fn test_corrupt_registry_rename_suffix_has_microseconds() {
         let temp = TempDir::new().unwrap();
@@ -569,14 +574,22 @@ mod tests {
         }
         let suffix = suffix.expect("corrupt sibling must exist");
 
-        // Must be exactly YYYYMMDD_HHMMSS_uuuuuu = 8+1+6+1+6 = 22 chars.
+        let (timestamp, rand_suffix) = suffix
+            .rsplit_once('-')
+            .expect("corrupt suffix must include a random hex suffix");
+        assert_eq!(rand_suffix.len(), 16);
+        assert!(rand_suffix
+            .chars()
+            .all(|c| c.is_ascii_digit() || ('a'..='f').contains(&c)));
+
+        // Timestamp must be exactly YYYYMMDD_HHMMSS_uuuuuu = 8+1+6+1+6 = 22 chars.
         assert_eq!(
-            suffix.len(),
+            timestamp.len(),
             22,
-            "corrupt suffix `{}` has unexpected length (chrono %6f bug?)",
-            suffix
+            "corrupt timestamp `{}` has unexpected length (chrono %6f bug?)",
+            timestamp
         );
-        let parts: Vec<&str> = suffix.split('_').collect();
+        let parts: Vec<&str> = timestamp.split('_').collect();
         assert_eq!(
             parts.len(),
             3,

--- a/docs/SECURITY_AUDIT_2026-04-21.md
+++ b/docs/SECURITY_AUDIT_2026-04-21.md
@@ -1,0 +1,333 @@
+# AxiomVault Security Audit — 2026-04-21
+
+**Auditor:** Claude (Opus 4.7) using `cybersecurity-skills` plugin (commit `72a2cd6`).
+**Scope:** `core/crypto`, `core/vault`, `core/storage`, `core/sync`, `core/ffi`, `core/fuse`, dependency tree.
+**Out of scope:** `clients/*` (Linux GTK, Apple SwiftUI, Android Kotlin), `tools/cli`, `core/webdav` (only inspected where it intersects scope), `core/common`.
+**Method:** Static source review + `cargo audit` + `cargo deny check` + targeted greps for unsafe blocks, panic surfaces, secret literals.
+
+---
+
+## Severity legend
+
+- **CRITICAL** — exploitable now, breaks confidentiality/integrity, fix immediately.
+- **HIGH** — exploitable under realistic conditions, or correctness gap that silently loses data.
+- **MEDIUM** — defense-in-depth gap, hardening issue, or exploitable only under non-default config.
+- **LOW** — code-quality / future-proofing issue with no current exploit path.
+- **INFO** — observation, no action required.
+
+---
+
+## Summary
+
+| ID  | Severity | Component | Title                                                                  |
+| --- | -------- | --------- | ---------------------------------------------------------------------- |
+| C-1 | CRITICAL | deps      | `rustls-webpki 0.103.10` — name-constraint bypass (RUSTSEC-2026-0098/9) |
+| H-1 | HIGH     | sync      | `download_remote_changes` discards downloaded data                     |
+| H-2 | HIGH     | ffi       | Recovery mnemonic exits over FFI as plain `String`/`CString` — never zeroized |
+| H-3 | HIGH     | ffi       | Passwords cloned into `String` at FFI boundary, never zeroized          |
+| M-1 | MEDIUM   | deps      | `rand 0.10.0` (and 0.8/0.9 transitives) — RUSTSEC-2026-0097 unsoundness |
+| M-2 | MEDIUM   | storage   | OAuth desktop client uses `client_secret` instead of PKCE              |
+| M-3 | MEDIUM   | storage   | OAuth CSRF verification not enforced at the library layer              |
+| M-4 | MEDIUM   | storage   | `LocalProvider` uses default umask — vault config + ciphertext world-readable on Linux |
+| M-5 | MEDIUM   | sync      | Plaintext-capable staging area writes data with default umask           |
+| M-6 | MEDIUM   | sync      | `generate_conflict_path` second-resolution timestamp races              |
+| M-7 | MEDIUM   | crypto    | `EncryptingStream` buffers entire encrypted output in RAM               |
+| M-8 | MEDIUM   | fuse      | `open()` reads entire decrypted file into RAM                           |
+| M-9 | MEDIUM   | fuse      | Two `unsafe { libc::getuid()/getgid() }` calls without `// SAFETY:` comments |
+| M-10| MEDIUM   | vault     | Migration framework (`MigrationRegistry`) only works for local-disk vaults |
+| L-1 | LOW      | crypto    | `encrypt_with_nonce` is a public footgun with no programmatic safeguard |
+| L-2 | LOW      | crypto    | `Salt` field is `pub` — externally mutable                              |
+| L-3 | LOW      | crypto    | `MasterKey::from_bytes` accepts `[u8; 32]` by value — caller copy not zeroized |
+| L-4 | LOW      | crypto    | `decrypted[..8].try_into().unwrap()` in `stream::decrypt_stream` lib code |
+| L-5 | LOW      | storage   | `build_http_client` has no total request timeout — DoS / hang risk      |
+| L-6 | LOW      | storage   | CRC-32 in erasure shards is non-cryptographic (defense-in-depth only)   |
+| L-7 | LOW      | sync      | `StagingArea::new` silently discards corrupted registry                  |
+| L-8 | LOW      | sync      | Retry executor doesn't refresh OAuth tokens on Authentication errors    |
+| L-9 | LOW      | fuse      | `open()` ignores `O_RDONLY/O_WRONLY/O_RDWR` flags                       |
+| L-10| LOW      | cli       | OAuth CSRF token compared with `!=` (non-constant-time)                 |
+| I-1 | INFO     | crypto    | Argon2id `interactive` profile is conservative (64 MiB / 3 iter)        |
+| I-2 | INFO     | vault     | `MigrationV1_0ToV1_1` is a no-op placeholder; real migration lives in `VaultConfig::migrate_to_v1_1` |
+
+---
+
+## Findings
+
+### C-1 — `rustls-webpki 0.103.10` name-constraint bypass (RUSTSEC-2026-0098 + 0099)
+
+**Severity:** CRITICAL. **Component:** transitive dependency.
+**Reachability:** Every cloud storage call (Google Drive, Dropbox, OneDrive, iCloud) traverses `reqwest → hyper-rustls → rustls → rustls-webpki`.
+
+Two related advisories from 2026-04-14:
+
+- **RUSTSEC-2026-0098** — name constraints for URI names incorrectly accepted.
+- **RUSTSEC-2026-0099** — name constraints accepted for certificates asserting a wildcard name.
+
+Both are misissuance-bypass bugs in `rustls-webpki ≤ 0.103.11`. AxiomVault relies on TLS to authenticate Google/Dropbox/OneDrive endpoints; a constrained intermediate CA could be tricked into accepting a cert outside its constraint.
+
+**Fix:** `cargo update -p rustls-webpki` (target version `>= 0.103.12`).
+
+After upgrade, re-run `cargo audit` to confirm. Pin in `Cargo.toml` if needed.
+
+---
+
+### H-1 — Sync engine discards downloaded remote data
+
+**Severity:** HIGH. **File:** `core/sync/src/engine.rs:520-547`.
+
+```rust
+match download_result {
+    Ok(_data) => {
+        // In a real implementation, we would write this to the vault
+        // For now, just update the state
+        ...
+```
+
+`download_remote_changes` downloads the ciphertext, then immediately drops `_data` and only updates the etag/timestamp in the in-memory sync state. **Remote-side changes are silently lost** — the local vault never sees them.
+
+**Fix:** Pipe `_data` into the vault's storage layer (write to local provider / staging area for a future commit, or directly invoke `VaultOperations::update_file` with the decrypted plaintext if applicable).
+
+This is a correctness gap that *masquerades* as success in the sync result counters, which makes it harder to detect operationally.
+
+---
+
+### H-2 — Recovery mnemonic leaves FFI without zeroization
+
+**Severity:** HIGH. **Files:** `core/ffi/src/lib.rs:441-462`, `core/ffi/src/vault_ops.rs:56`, `core/ffi/src/vault_ops.rs:206-209`.
+
+The recovery key is 256 bits of master-key-equivalent entropy. The vault crate correctly wraps it in `Zeroizing<String>` (`recovery.rs:62`). But at the FFI boundary it is converted to a plain `String`:
+
+```rust
+// vault_ops.rs:56
+recovery_words: std::sync::Mutex::new(Some(String::from(&*result.recovery_words))),
+```
+
+```rust
+// lib.rs:456
+Some(w) => CString::new(w).map(|s| s.into_raw())  // heap-allocated copy, dropped without zeroize
+```
+
+The `Zeroizing` wrapper is dropped at the boundary; the resulting `String` and `CString` heap allocations are freed without being wiped. Same pattern in `axiom_vault_show_recovery_key` (`lib.rs:478`) and `vault_ops::show_recovery_key` (`vault_ops.rs:206-209`).
+
+**Why it matters:** anyone who can read process memory after a vault was created/recovered (core dump, swap file, debugger, attached profiler) can reconstruct the master key.
+
+**Fix:**
+- Hold `Zeroizing<String>` end-to-end inside `FFIVaultHandle.recovery_words`.
+- Write a small helper that copies straight from `Zeroizing<String>` into a heap buffer the FFI caller will free, and zeroize the source after the copy.
+- For `axiom_string_free` of recovery output specifically, zeroize the bytes before `CString::from_raw` drops them, *or* expose a separate `axiom_recovery_words_free` that zeroizes.
+
+---
+
+### H-3 — Passwords are heap-`String`-cloned across the FFI boundary
+
+**Severity:** HIGH. **Files:** `core/ffi/src/vault_ops.rs:46, 70, 178, 222`.
+
+Every password-taking entry point converts the C string into `&str`, then immediately calls `.to_string()` to build `CreateVaultParams { password: password.to_string(), ... }` etc. The resulting `String` lives on the heap until `CreateVaultParams` is dropped, with no zeroization.
+
+Cumulative effect across `create_vault`, `open_vault`, `change_password` (twice — old + new), and `reset_password`: up to 5 password copies per session, each persisting on the allocator's freelist after drop.
+
+**Fix:** make `*Params` structs hold `Zeroizing<String>` (or `SecretString`/`secrecy` crate) for password fields, and propagate that all the way down to `derive_key`.
+
+---
+
+### M-1 — `rand` unsoundness (RUSTSEC-2026-0097)
+
+**Severity:** MEDIUM. **Versions present:** 0.8.5, 0.9.2, 0.10.0.
+
+> Rand is unsound with a custom logger using `rand::rng()`.
+
+AxiomVault uses `rand::rng().fill(...)` in `crypto/keys.rs`, `crypto/recovery.rs`, and `sync/retry.rs`. Exploitability requires a custom `tracing`/`log` subscriber that reentrantly calls `rand::rng()`, which AxiomVault itself does not install. **Risk depends on what the embedding application installs at runtime** (e.g. a mobile app with custom telemetry).
+
+**Fix:** monitor RustSec for a fixed `rand` release; once available, run `cargo update -p rand`. Until then, document the constraint that subscribers/loggers must not invoke `rand::rng()` reentrantly. Consider adding the advisory to `deny.toml` ignore list with an expiry date and tracking issue.
+
+---
+
+### M-2 — Desktop OAuth client uses `client_secret` (no PKCE)
+
+**Severity:** MEDIUM. **File:** `core/storage/src/gdrive/auth.rs:91-109` (and the analogous Dropbox/OneDrive auth modules).
+
+RFC 8252 (OAuth 2.0 for Native Apps) requires PKCE for public clients and discourages embedded `client_secret`s, because anyone with the binary can extract them. AxiomVault distributes the desktop/mobile binary, then expects users to provide `AXIOMVAULT_GOOGLE_CLIENT_ID/SECRET` via env. While that pushes the secret out of the binary, it *also* means the secret can be replayed by anyone who can read the env (e.g. another local user, a compromised process).
+
+**Fix:** switch to PKCE (`code_challenge`/`code_verifier`) and drop the client secret. The `oauth2` crate supports `set_pkce_challenge`. This eliminates a class of credential-theft scenarios.
+
+---
+
+### M-3 — OAuth CSRF token verification is the caller's job
+
+**Severity:** MEDIUM. **File:** `core/storage/src/gdrive/auth.rs:124-147`.
+
+`AuthManager::authorization_url()` returns `(url, csrf_token)`, but `exchange_code(code)` does **not** take the original token to verify against the callback's `state` parameter. CLI does verify (`tools/cli/src/main.rs:1312`), but other callers (mobile clients, future integrations) could forget — and the library wouldn't notice.
+
+**Fix:** either (a) require the CSRF token as an argument to `exchange_code` and verify internally before exchanging, or (b) provide a higher-level method that takes the full callback URL and verifies state before exchanging code. Make the *unsafe* path (no verification) explicitly opt-in.
+
+---
+
+### M-4 — `LocalProvider` writes vault config and ciphertext with default umask
+
+**Severity:** MEDIUM. **File:** `core/storage/src/local.rs:82-116`.
+
+`fs::write` and `fs::rename` use the process umask, so on Linux the vault config (containing wrapped master keys + KDF params) and all ciphertext files are typically `0644` — readable by every local user. While the data is encrypted, this widens the attack surface unnecessarily: an attacker on the same host can offline-attack passwords against the wrapped key without escalating privileges.
+
+**Fix:** explicitly `chmod 0600` (file) / `0700` (directory) after creation, or use `OpenOptions::mode(0o600)` on the temp path before rename.
+
+---
+
+### M-5 — Staging area files inherit default umask, may contain plaintext
+
+**Severity:** MEDIUM. **File:** `core/sync/src/staging.rs:78-103`.
+
+`StagingArea::stage_upload` calls `fs::write(&staging_file, &data)` with no permission bits set. Whether the data is plaintext depends on the caller; for any caller that stages plaintext (the vault's intent is to encrypt before staging, but that's a layering contract not enforced by the type), default umask leaves it world-readable.
+
+**Fix:** set `0600` on the staging file. Additionally, document the layering contract loud in `staging.rs`: "The bytes passed here MUST be ciphertext."
+
+---
+
+### M-6 — `generate_conflict_path` uses second-resolution timestamps
+
+**Severity:** MEDIUM. **File:** `core/sync/src/conflict.rs:118-130`.
+
+`format!("%Y%m%d_%H%M%S")` — two conflicts on the same path within the same wall-clock second produce identical renamed paths. With `KeepBoth` strategy this means the second conflict's `provider.upload(&renamed_path, local_data)` silently overwrites the first conflict's file, losing data.
+
+**Fix:** include sub-second precision (`%f` in chrono) and/or a short random suffix.
+
+---
+
+### M-7 — `EncryptingStream::encrypt_stream` buffers the entire encrypted output
+
+**Severity:** MEDIUM. **File:** `core/crypto/src/stream.rs:77-115`.
+
+The doc comment acknowledges the issue:
+
+> The current implementation reads all encrypted chunks into a Vec before writing, because total_chunks is written in the header and cannot be known until all chunks are processed. For large files this doubles peak memory usage.
+
+For a 4 GB file this means ~8 GB of resident memory. That is a DoS condition on phones / FUSE mounts and a non-trivial wallclock+I/O cost on desktops.
+
+**Fix (recommended in the doc):** drop `total_chunks` from the header; rely on EOF. Alternatively, write to a tempfile and seek back to overwrite the header.
+
+---
+
+### M-8 — FUSE `open()` reads the full decrypted file into RAM
+
+**Severity:** MEDIUM. **File:** `core/fuse/src/filesystem.rs:392-459`.
+
+```rust
+let buffer = match ops.read_file(&path).await { ... };  // entire plaintext in heap
+```
+
+The `OpenFile.buffer` lives until `release()`, so a malicious or buggy FUSE client opening many large files at once can exhaust memory. Plaintext exposure window is also longer than necessary.
+
+**Fix:** chunked/streaming reads, or at minimum a configurable max-in-memory size. Pair with `EncryptingStream` once M-7 is fixed.
+
+---
+
+### M-9 — Missing `// SAFETY:` comments on `unsafe` blocks
+
+**Severity:** MEDIUM. **File:** `core/fuse/src/filesystem.rs:42-43`.
+
+```rust
+uid: unsafe { libc::getuid() },
+gid: unsafe { libc::getgid() },
+```
+
+Per `CLAUDE.md` and the pre-commit hook, every `unsafe` block requires a `// SAFETY:` comment. These are missing. The pre-commit hook should be catching this — verify it actually does (and if not, fix the hook).
+
+**Fix:** add comments such as `// SAFETY: getuid/getgid are async-signal-safe POSIX syscalls and have no preconditions.` Then verify `.githooks/` actually rejects future violations.
+
+---
+
+### M-10 — Migration framework is local-disk only
+
+**Severity:** MEDIUM. **File:** `core/vault/src/migration.rs`.
+
+`MigrationRegistry::migrate` uses `std::fs::copy/read/write` directly on a `vault_path: &Path`. For cloud-backed vaults (Google Drive, Dropbox, etc.), this path doesn't exist — migration would fail. The actual v1.0→v1.1 upgrade logic lives in `VaultConfig::migrate_to_v1_1` (`config.rs:347`) and operates on the in-memory config; the registry's `MigrationV1_0ToV1_1` is a no-op placeholder that just bumps the version field.
+
+**Risk:** future structural migrations can't be applied to cloud vaults without rework. Today this is dormant (only one migration exists, and it's a placeholder).
+
+**Fix:** replace `vault_path: &Path` with `provider: &dyn StorageProvider` so backup/restore go through the storage abstraction.
+
+---
+
+### L-1 — `encrypt_with_nonce` is a public footgun
+
+**File:** `core/crypto/src/aead.rs:104-135`. Public API; nonce reuse with the same key catastrophically breaks XChaCha20. The doc warns, but there is no programmatic safeguard (e.g., a typed wrapper that tracks (key, nonce) pairs, or `pub(crate)` visibility).
+
+**Fix:** at minimum, restrict to `pub(crate)` if no external consumer needs it. If filename encryption needs determinism, build a typed `DeterministicCipher` newtype that owns its own nonce-derivation strategy.
+
+### L-2 — `Salt` exposes inner bytes mutably
+
+**File:** `core/crypto/src/keys.rs:152` — `pub struct Salt(pub [u8; 32])`. Salt is not secret, but the `pub` field invites bugs (e.g., overwriting after derivation). Use a private field with a getter.
+
+### L-3 — `MasterKey::from_bytes(key: [u8; KEY_LENGTH])` takes the array by value
+
+**File:** `core/crypto/src/keys.rs:33`. The caller's stack copy is not zeroized. Today most callers wrap their input in `Zeroizing<[u8; 32]>` and dereference; that drops the wrapper after the move, so the move itself is fine. But the type signature doesn't enforce this discipline. Consider taking `Zeroizing<[u8; 32]>` directly, or `&mut [u8; 32]` and zeroing in-place.
+
+### L-4 — `.unwrap()` in production code path
+
+**File:** `core/crypto/src/stream.rs:196` — `decrypted[..8].try_into().unwrap()`. The preceding length check makes it provably unreachable, but `.expect("len >= 8 verified above")` is more honest and would survive a future refactor that drops the check.
+
+### L-5 — HTTP client lacks total request timeout
+
+**File:** `core/storage/src/http_client.rs:25-31`. `connect_timeout(10s)` only covers TCP connect. A slow/malicious server can hang the whole sync forever. Add per-request timeouts, especially for metadata calls (which should be sub-second), while keeping streaming uploads/downloads unbounded.
+
+### L-6 — Erasure-shard CRC-32 is non-cryptographic
+
+**File:** `core/storage/src/composite/erasure.rs:144-149`. CRC-32 detects bit rot, not tampering. A backend that mutates a shard can recompute the CRC. This is fine in practice because the AEAD tag at the vault layer catches all tampering, but it's worth a comment that the CRC is *only* for integrity-against-noise, not authenticity.
+
+### L-7 — Staging registry corruption is silent
+
+**File:** `core/sync/src/staging.rs:65` — `serde_json::from_str(&content).unwrap_or_default()`. A corrupted registry silently drops all in-flight changes. Log a warning at minimum; consider failing fast so the user can recover.
+
+### L-8 — Retry executor doesn't retry on `Authentication` errors
+
+**File:** `core/sync/src/retry.rs:161-163`. Only `Network` and `Io` are retried. An expired token surfaces as `Authentication`, so the retry doesn't kick in to allow the token manager to refresh. In practice the `CloudTokenManager` refreshes proactively (5-min buffer), so this is rarely visible — but add `Authentication` to the retryable set if you ever miss the buffer window.
+
+### L-9 — FUSE `open()` ignores access flags
+
+**File:** `core/fuse/src/filesystem.rs:392`. `O_RDONLY`/`O_WRONLY`/`O_RDWR` are not honored — every open returns a writable handle. Kernel `default_permissions` mitigates this for cross-user access, but in-process logic that expects RDONLY semantics is unprotected.
+
+### L-10 — CSRF token comparison is non-constant-time (CLI)
+
+**File:** `tools/cli/src/main.rs:1312`. `received_state != csrf_token` is `String` `PartialEq`, which short-circuits on the first byte mismatch. CSRF tokens are short-lived single-use values delivered via HTTP, so a remote timing attack is impractical — but `subtle::ConstantTimeEq` is one line and removes the question.
+
+---
+
+## Informational notes
+
+- **I-1:** `KdfParams::interactive` (64 MiB / 3 iter / 4 par) meets but does not exceed OWASP 2023 minimum (19 MiB / 2 iter / 1 par). For desktops, consider `sensitive` (256 MiB) as the default — Argon2id memory cost is the main defense against ASIC/GPU attackers.
+- **I-2:** `MigrationRegistry::with_defaults()` registers `MigrationV1_0ToV1_1`, which is a no-op (just bumps version). The real v1.0→v1.1 wrapping logic is `VaultConfig::migrate_to_v1_1`. Two separate flows for the same conceptual change is confusing — pick one and document the relationship.
+
+---
+
+## Positive findings (defense-in-depth working as intended)
+
+- AEAD primitive choice (XChaCha20-Poly1305) is correct: 24-byte random nonces are safe.
+- Argon2id used with sane defaults; constant-time password verification via `subtle::ct_eq`.
+- Master-key wrapping under both password-KEK and recovery-KEK — password change re-wraps the master key without re-encrypting all data.
+- `Zeroize`/`ZeroizeOnDrop` consistently derived on `MasterKey`, `FileKey`, `DirectoryKey`, `RecoveryKey`, `CloudTokens`.
+- `Debug` for key types is overridden to `[REDACTED]`.
+- Stream-encryption per-chunk index is authenticated, defending against chunk reorder/injection.
+- `VaultPath` rejects `.`, `..`, and path separators inside components — path traversal is blocked at the type level (verified by proptest in `core/common/src/types.rs`).
+- `LocalProvider::upload` is atomic (write-temp-then-rename) — no torn writes.
+- `ShardMap` uses tombstones to prevent resurrection of deleted entries when merging diverged backends.
+- Pre-commit pipeline includes `gitleaks`, `cargo fmt --check`, `cargo clippy -D warnings`, and an unsafe-block SAFETY check.
+- `cargo deny` is configured strictly: only crates.io sources, denylist for unknown registries/git.
+
+---
+
+## Recommended next steps (prioritized)
+
+1. **`cargo update -p rustls-webpki`** to resolve C-1, then re-run `cargo audit`.
+2. Fix H-1 (sync data loss) — this is silently corrupting state right now.
+3. Pipe `Zeroizing` end-to-end through the FFI boundary (H-2, H-3).
+4. Add `0600` mode to `LocalProvider` and staging writes (M-4, M-5).
+5. Switch desktop OAuth to PKCE (M-2) and verify CSRF inside the library (M-3).
+6. Add the missing `// SAFETY:` comments and verify the pre-commit hook actually rejects them in the future (M-9).
+7. Track the `rand` advisory; add to `deny.toml` ignore with an expiry tracking issue if a fix is not yet released (M-1).
+
+---
+
+## Tooling provenance
+
+- `cargo audit` ran against advisory-db `1049 advisories` snapshot.
+- `cargo deny check` — `advisories FAILED, bans ok, licenses ok, sources ok` (the FAILED line is C-1 / M-1).
+- Plugin: `anthropic-cybersecurity-skills` (commit `72a2cd6`, 754 skills).
+- No dynamic analysis (fuzzing, sanitizer runs) was performed — recommended as a follow-up for `core/crypto` and `core/storage/composite/erasure`.


### PR DESCRIPTION
## Summary

Addresses **12 of 26 findings** from the security audit checked in at `docs/SECURITY_AUDIT_2026-04-21.md`. Verified clean: `cargo audit`, `cargo build`, `cargo fmt --check`, `cargo clippy -D warnings`, and 440 workspace tests passing.

| ID  | Severity | Component | Fix |
|-----|----------|-----------|-----|
| C-1 | CRITICAL | deps     | `rustls-webpki` 0.103.10 → 0.103.12 (RUSTSEC-2026-0098/0099) |
| H-1 | HIGH     | sync     | `download_remote_changes` no longer lies about persistence — new `pending_persistence` counter, no false etag mutation, loud warn |
| H-2 | HIGH     | ffi      | Recovery mnemonic is `Zeroizing<String>` end-to-end; new `axiom_recovery_words_free` wipes before drop |
| H-3 | HIGH     | ffi      | Passwords are `Zeroizing<String>` from FFI through Params/AppService |
| M-4 | MEDIUM   | storage  | `LocalProvider` writes files mode 0600, dirs mode 0700 on Unix |
| M-5 | MEDIUM   | sync     | `StagingArea` files mode 0600, dir mode 0700 on Unix; doc says input MUST be ciphertext |
| M-6 | MEDIUM   | sync     | `generate_conflict_path` adds microseconds + 4-char random hex suffix |
| M-9 | MEDIUM   | fuse     | `// SAFETY:` comments added; `.githooks/check-unsafe.sh` hardened to catch inline `unsafe { ... }` (was only matching line-start) |
| L-5 | LOW      | storage  | New `build_metadata_http_client()` with 30s timeout for metadata-style cloud calls; streaming uploads/downloads stay unbounded |
| L-6 | LOW      | storage  | Inline note clarifying CRC-32 is bit-rot detection only; AEAD provides authenticity |
| L-7 | LOW      | sync     | Corrupt staging registry is renamed to `staging_registry.json.corrupt-{ts}` and a fresh registry started |
| L-8 | LOW      | sync     | Retry executor now retries `Error::Authentication` so `CloudTokenManager` can refresh on second attempt |

## API breaks (intentional, no compat shims)

- `AppService::change_password(&str, &str)` → `(Zeroizing<String>, Zeroizing<String>)`
- `CreateVaultParams.password` / `OpenVaultParams.password` / `RecoverVaultParams.{recovery_words,new_password}` are now `Zeroizing<String>`
- `VaultCreatedDto.recovery_words` is `Zeroizing<String>`; `*Params` and `VaultCreatedDto` no longer derive `Serialize`/`Deserialize` (secret-bearing types shouldn't round-trip through serde)
- New C-FFI export `axiom_recovery_words_free` — calling `axiom_string_free` on output from `axiom_vault_get_recovery_words` / `axiom_vault_show_recovery_key` is **now a bug**. Apple bridging header + Swift wrapper updated. Android JNI doesn't touch recovery words so no change there.
- `download_remote_changes` returns `(usize, usize, usize)` instead of `(usize, usize)` to surface `pending_persistence`; `SyncResult` extended with the new field (`#[serde(default)]` so old serialized results still deserialize)

## Out of scope (deferred to follow-up)

11 findings remain: M-1 (rand upstream fix needed), M-2 (PKCE OAuth), M-3 (CSRF library enforcement), M-7 (streaming format change — breaking format, needs sign-off), M-8 (FUSE chunked open, depends on M-7), M-10 (migration framework cloud), L-1..L-4 (crypto polish), L-9 (FUSE flags), L-10 (CSRF constant-time compare in CLI).

## Test plan

- [x] `cargo audit` — RUSTSEC-2026-0098/0099 cleared
- [x] `cargo build --workspace --exclude axiomvault-linux`
- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --exclude axiomvault-linux --all-targets --all-features -- -D warnings`
- [x] `cargo test --workspace --exclude axiomvault-linux` — 440 passed, 0 failed
- [x] Pre-commit hooks (gitleaks, fmt, hardened SAFETY check, clippy, build) green per commit
- [ ] CI matrix on Ubuntu + macOS, stable + MSRV (1.85.0) — defer to CI
- [ ] Mobile clients build with new `axiom_recovery_words_free` symbol — verify on next mobile cycle

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Conflict filenames now include microsecond timestamps plus random suffixes.
  * Recovery words shown via a one-time modal dialog with copy/clear behavior.

* **Bug Fixes**
  * Improved secret handling: passwords and recovery words are zeroized and explicitly freed after use.
  * Metadata requests use a bounded client to avoid hangs/timeouts.
  * Retry logic treats expired authentication as transient for better sync resilience.

* **Security**
  * Hardened Unix file/directory permissions.
  * Added a comprehensive security audit report.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->