### PR TITLE
docs: clarify quantum-resistant vault encryption scope

### DIFF
--- a/README.md
+++ b/README.md
@@ -207,7 +207,7 @@ vault-root/
 - **Chunk ordering protection** &mdash; chunk index is authenticated to prevent reordering
 - **Memory safety** &mdash; `Zeroize` + `ZeroizeOnDrop` on all key types, `subtle` for constant-time ops
 - **No plaintext in logs** &mdash; keys and sensitive data are redacted in `Display` impls
-- **Quantum-resistant vault encryption** &mdash; AxiomVault uses quantum-resistant client-side encryption for vault contents and encrypted filenames, based on 256-bit symmetric AEAD encryption and password/recovery-key based key wrapping. This claim excludes TLS, OAuth, and cloud-provider identity layers.
+- **Quantum-resistant vault encryption** &mdash; AxiomVault uses quantum-resistant client-side encryption for vault contents and encrypted filenames, based on 256-bit symmetric AEAD encryption and password/recovery-key based key wrapping. Password-protected vault strength remains bounded by the user's password entropy, so use a strong password or the high-entropy recovery key for post-quantum-strength access. This claim excludes TLS, OAuth, and cloud-provider identity layers.
 
 ## Development
 

--- a/README.md
+++ b/README.md
@@ -207,6 +207,7 @@ vault-root/
 - **Chunk ordering protection** &mdash; chunk index is authenticated to prevent reordering
 - **Memory safety** &mdash; `Zeroize` + `ZeroizeOnDrop` on all key types, `subtle` for constant-time ops
 - **No plaintext in logs** &mdash; keys and sensitive data are redacted in `Display` impls
+- **Quantum-resistant vault encryption** &mdash; AxiomVault uses quantum-resistant client-side encryption for vault contents and encrypted filenames, based on 256-bit symmetric AEAD encryption and password/recovery-key based key wrapping. This claim excludes TLS, OAuth, and cloud-provider identity layers.
 
 ## Development
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -56,7 +56,7 @@ There is no bug bounty program at this time. We will credit reporters in release
 
 ### Quantum-resistance scope
 
-AxiomVault uses quantum-resistant client-side encryption for vault contents and encrypted filenames, based on 256-bit symmetric AEAD encryption and password/recovery-key based key wrapping. This claim excludes TLS, OAuth, and cloud-provider identity layers.
+AxiomVault uses quantum-resistant client-side encryption for vault contents and encrypted filenames, based on 256-bit symmetric AEAD encryption and password/recovery-key based key wrapping. Password-protected vault strength remains bounded by the user's password entropy, so use a strong password or the high-entropy recovery key for post-quantum-strength access. This claim excludes TLS, OAuth, and cloud-provider identity layers.
 
 ### Key hierarchy
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -54,6 +54,10 @@ There is no bug bounty program at this time. We will credit reporters in release
 | Non-KDF hashing | Blake2b | Used for file/directory key derivation and recovery KEK derivation |
 | Recovery key encoding | BIP39 mnemonic | 24 words encoding 256 bits of entropy |
 
+### Quantum-resistance scope
+
+AxiomVault uses quantum-resistant client-side encryption for vault contents and encrypted filenames, based on 256-bit symmetric AEAD encryption and password/recovery-key based key wrapping. This claim excludes TLS, OAuth, and cloud-provider identity layers.
+
 ### Key hierarchy
 
 ```text

--- a/docs/threat-model.md
+++ b/docs/threat-model.md
@@ -107,7 +107,7 @@ level because they are operationally necessary and not vault secrets.
 
 ## Quantum-Resistance Scope
 
-AxiomVault uses quantum-resistant client-side encryption for vault contents and encrypted filenames, based on 256-bit symmetric AEAD encryption and password/recovery-key based key wrapping. This claim excludes TLS, OAuth, and cloud-provider identity layers.
+AxiomVault uses quantum-resistant client-side encryption for vault contents and encrypted filenames, based on 256-bit symmetric AEAD encryption and password/recovery-key based key wrapping. Password-protected vault strength remains bounded by the user's password entropy, so use a strong password or the high-entropy recovery key for post-quantum-strength access. This claim excludes TLS, OAuth, and cloud-provider identity layers.
 
 ## Out of Scope
 

--- a/docs/threat-model.md
+++ b/docs/threat-model.md
@@ -105,6 +105,10 @@ level because they are operationally necessary and not vault secrets.
 | Random generation | OS CSPRNG via `rand` | Used for keys, salts, nonces |
 | Constant-time comparison | `subtle` crate | Password verification, recovery verification |
 
+## Quantum-Resistance Scope
+
+AxiomVault uses quantum-resistant client-side encryption for vault contents and encrypted filenames, based on 256-bit symmetric AEAD encryption and password/recovery-key based key wrapping. This claim excludes TLS, OAuth, and cloud-provider identity layers.
+
 ## Out of Scope
 
 - Protection against a compromised OS kernel or hypervisor.


### PR DESCRIPTION
## Summary
- document the scoped quantum-resistance claim in README, SECURITY, and threat model
- explicitly exclude TLS, OAuth, and cloud-provider identity layers from the claim

## Testing
- cargo test --workspace