### PR TITLE
fix: resolve post-merge security audit failures

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -93,9 +93,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.102"
+version = "1.0.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+checksum = "2a4385e2e34eb35d6b3efe798b9eb88096925d87726c0798709bf56d9ed84af3"
 
 [[package]]
 name = "argon2"
@@ -2271,9 +2271,9 @@ dependencies = [
 
 [[package]]
 name = "quinn-proto"
-version = "0.11.14"
+version = "0.11.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
+checksum = "4fcb935c5bec503c2f0e306bdd3e58bb9029dcb14fa8d9ac76e3a5256ac0763e"
 dependencies = [
  "aws-lc-rs",
  "bytes",


### PR DESCRIPTION
## Summary
- fixes the post-merge `Rust CI - master (c475fb7)` failure after #196
- updates `quinn-proto` from 0.11.14 to 0.11.15 to address `RUSTSEC-2026-0185`
- updates `anyhow` from 1.0.102 to 1.0.103 to satisfy cargo-deny advisory checks

## Validation
- `cargo audit` ✅
- `cargo deny check advisories` ✅
- `cargo deny check` ✅

Full workspace compile was not run locally because this machine is missing GTK/GLib system packages required by the Linux desktop crate; GitHub CI will cover that environment.

Related failed run: https://github.com/5queezer/axiom-vault/actions/runs/28459879561
