### PR TITLE
fix: satisfy current stable clippy

### DIFF
--- a/core/vault/src/migration.rs
+++ b/core/vault/src/migration.rs
@@ -101,22 +101,17 @@ impl MigrationRegistry {
         let mut current = *from;
 
         while current != *to {
-            let next = self
+            let migration = self
                 .migrations
                 .iter()
-                .find(|m| m.source_version() == current);
-            match next {
-                Some(migration) => {
-                    let target = migration.target_version();
-                    // Ensure we're moving forward and not past our target.
-                    if target.minor > to.minor || target.major != to.major {
-                        return None;
-                    }
-                    path.push(migration.as_ref());
-                    current = target;
-                }
-                None => return None,
+                .find(|m| m.source_version() == current)?;
+            let target = migration.target_version();
+            // Ensure we're moving forward and not past our target.
+            if target.minor > to.minor || target.major != to.major {
+                return None;
             }
+            path.push(migration.as_ref());
+            current = target;
         }
 
         Some(path)

--- a/tools/cli/src/main.rs
+++ b/tools/cli/src/main.rs
@@ -1214,7 +1214,7 @@ fn print_health_report(report: &axiomvault_vault::HealthReport) {
 async fn cmd_gdrive_auth(
     client_id: Option<String>,
     client_secret: Option<String>,
-    output: &PathBuf,
+    output: &Path,
 ) -> Result<()> {
     info!("Starting Google Drive authentication");
 


### PR DESCRIPTION
## Summary
- replace a migration-path `match` with `Option::?`
- restore compatibility with the new `clippy::question_mark` lint in current stable Rust

## Validation
- `cargo test -p axiomvault-vault migration::tests` — 10 passed
- `cargo clippy -p axiomvault-vault --all-targets -- -D warnings`
- `cargo fmt --all -- --check`

This fixes the baseline Clippy failure currently affecting unrelated PRs, including #220.
