### PR TITLE
fix(webdav): require session auth and enforce loopback binding

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -370,17 +370,21 @@ dependencies = [
  "axiomvault-storage",
  "axiomvault-vault",
  "axum",
+ "base64",
  "chrono",
  "http",
  "http-body-util",
  "hyper",
  "percent-encoding",
+ "rand 0.10.2",
  "reqwest 0.13.4",
  "serde_json",
+ "subtle",
  "tempfile",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
+ "zeroize",
 ]
 
 [[package]]

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -24,13 +24,15 @@ There is no bug bounty program at this time. We will credit reporters in release
 
 - **Disk attacker (stolen device).** The vault master key is never stored in plaintext. It is wrapped (encrypted) under a key-encryption key (KEK) derived from the user's password via Argon2id with a per-vault random salt. Sensitive types in memory derive `Zeroize`/`ZeroizeOnDrop` and are wiped when they go out of scope.
 
-- **Network eavesdropper.** All cloud API traffic uses TLS (via `rustls`). The local FUSE mount is process-local and does not expose a network service.
+- **Network eavesdropper.** All cloud API traffic uses TLS (via `rustls`). The local FUSE mount is process-local and does not expose a network service. The optional WebDAV server is restricted by the library to loopback IP addresses and requires a cryptographically random, per-server HTTP Basic credential for every request other than capability discovery (`OPTIONS`).
 
 - **Partial cloud data loss.** Cloud RAID modes (mirror and erasure coding via Reed-Solomon) replicate data across multiple storage providers for redundancy.
 
 ### What we do NOT protect against
 
 - **Local malware with root/admin access.** An attacker with full system access can read process memory, inject code, or intercept FUSE operations. This is out of scope for AxiomVault.
+
+- **A local process that obtains the active WebDAV credential.** Loopback binding is not an OS-user security boundary. The CLI intentionally displays the session credential once so the user can configure a WebDAV client; protect terminal output and process memory. The credential is never persisted, is replaced whenever the server is restarted, and is redacted from debug output.
 
 - **Memory forensics on a running system.** We zeroize sensitive data eagerly, but we cannot guarantee all copies are erased. The compiler may optimize away zeroization in some cases, and secrets may leak to swap or core dumps. Use full-disk encryption as defense in depth.
 

--- a/core/webdav/Cargo.toml
+++ b/core/webdav/Cargo.toml
@@ -26,6 +26,10 @@ tracing.workspace = true
 # Utils
 chrono.workspace = true
 percent-encoding.workspace = true
+base64.workspace = true
+rand.workspace = true
+subtle.workspace = true
+zeroize.workspace = true
 
 [dev-dependencies]
 axiomvault-crypto = { path = "../crypto" }

--- a/core/webdav/src/auth.rs
+++ b/core/webdav/src/auth.rs
@@ -1,0 +1,101 @@
+//! Session-scoped credentials and HTTP Basic authentication.
+
+use std::fmt;
+
+use axum::http::header::AUTHORIZATION;
+use axum::http::HeaderMap;
+use base64::engine::general_purpose::{STANDARD, URL_SAFE_NO_PAD};
+use base64::Engine;
+use rand::RngExt;
+use subtle::ConstantTimeEq;
+use zeroize::Zeroizing;
+
+/// Username used by WebDAV clients for HTTP Basic authentication.
+pub const WEBDAV_USERNAME: &str = "axiomvault";
+
+/// A random password valid only for one [`crate::WebDavServer`] instance.
+pub struct WebDavCredential {
+    password: Zeroizing<String>,
+}
+
+impl WebDavCredential {
+    /// Generate a credential containing 256 bits of cryptographic randomness.
+    pub fn generate() -> Self {
+        let mut random = Zeroizing::new([0_u8; 32]);
+        rand::rng().fill(&mut random[..]);
+        Self {
+            password: Zeroizing::new(URL_SAFE_NO_PAD.encode(&random[..])),
+        }
+    }
+
+    /// Return the fixed username accepted by WebDAV clients.
+    pub const fn username(&self) -> &'static str {
+        WEBDAV_USERNAME
+    }
+
+    /// Expose the password for intentional one-time display to the local user.
+    pub fn password(&self) -> &str {
+        self.password.as_str()
+    }
+
+    pub(crate) fn authorizes(&self, headers: &HeaderMap) -> bool {
+        let Some(encoded) = headers
+            .get(AUTHORIZATION)
+            .and_then(|value| value.to_str().ok())
+            .and_then(|value| value.strip_prefix("Basic "))
+        else {
+            return false;
+        };
+
+        let Ok(decoded) = STANDARD.decode(encoded) else {
+            return false;
+        };
+        let decoded = Zeroizing::new(decoded);
+        let Some(separator) = decoded.iter().position(|byte| *byte == b':') else {
+            return false;
+        };
+        let (username, password_with_separator) = decoded.split_at(separator);
+        let password = &password_with_separator[1..];
+
+        username == WEBDAV_USERNAME.as_bytes()
+            && password.len() == self.password.len()
+            && bool::from(password.ct_eq(self.password.as_bytes()))
+    }
+}
+
+impl fmt::Debug for WebDavCredential {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("WebDavCredential")
+            .field("username", &WEBDAV_USERNAME)
+            .field("password", &"[REDACTED]")
+            .finish()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn generated_credentials_are_random_and_cli_safe() {
+        let first = WebDavCredential::generate();
+        let second = WebDavCredential::generate();
+
+        assert_eq!(first.password().len(), 43);
+        assert!(first
+            .password()
+            .bytes()
+            .all(|byte| byte.is_ascii_alphanumeric() || matches!(byte, b'-' | b'_')));
+        assert_ne!(first.password(), second.password());
+    }
+
+    #[test]
+    fn debug_output_redacts_password() {
+        let credential = WebDavCredential::generate();
+        let debug = format!("{credential:?}");
+
+        assert!(debug.contains("[REDACTED]"));
+        assert!(!debug.contains(credential.password()));
+    }
+}

--- a/core/webdav/src/config.rs
+++ b/core/webdav/src/config.rs
@@ -1,5 +1,9 @@
 //! WebDAV server configuration.
 
+use std::net::{IpAddr, SocketAddr};
+
+use axiomvault_common::{Error, Result};
+
 /// Configuration for the WebDAV server.
 #[derive(Debug, Clone)]
 pub struct WebDavConfig {
@@ -24,6 +28,52 @@ impl Default for WebDavConfig {
 impl WebDavConfig {
     /// Build a socket address string from bind_address and port.
     pub fn socket_addr(&self) -> String {
-        format!("{}:{}", self.bind_address, self.port)
+        self.bind_address
+            .parse::<IpAddr>()
+            .map(|ip| SocketAddr::new(ip, self.port).to_string())
+            .unwrap_or_else(|_| format!("{}:{}", self.bind_address, self.port))
+    }
+
+    /// Parse and enforce the library's loopback-only binding invariant.
+    pub(crate) fn validated_socket_addr(&self) -> Result<SocketAddr> {
+        let ip = self.bind_address.parse::<IpAddr>().map_err(|_| {
+            Error::InvalidInput("WebDAV bind address must be a loopback IP address".to_string())
+        })?;
+
+        if !ip.is_loopback() {
+            return Err(Error::InvalidInput(
+                "WebDAV bind address must be loopback".to_string(),
+            ));
+        }
+
+        Ok(SocketAddr::new(ip, self.port))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn both_ip_loopback_families_are_valid() {
+        for bind_address in ["127.0.0.1", "::1"] {
+            let config = WebDavConfig {
+                bind_address: bind_address.to_owned(),
+                ..Default::default()
+            };
+            assert!(config.validated_socket_addr().unwrap().ip().is_loopback());
+        }
+    }
+
+    #[test]
+    fn hostnames_are_rejected_instead_of_resolved() {
+        let config = WebDavConfig {
+            bind_address: "localhost".to_owned(),
+            ..Default::default()
+        };
+        assert!(matches!(
+            config.validated_socket_addr(),
+            Err(Error::InvalidInput(_))
+        ));
     }
 }

--- a/core/webdav/src/handler.rs
+++ b/core/webdav/src/handler.rs
@@ -17,12 +17,14 @@ use axiomvault_common::VaultPath;
 use axiomvault_vault::{VaultOperations, VaultSession};
 
 use crate::xml::{self, PropEntry};
+use crate::WebDavCredential;
 
 /// Shared application state passed to all handlers.
 #[derive(Clone)]
 pub struct AppState {
     pub session: Arc<VaultSession>,
     pub max_body_size: usize,
+    pub credential: Arc<WebDavCredential>,
 }
 
 /// Top-level router: dispatches by HTTP method.
@@ -31,6 +33,18 @@ pub async fn handle_request(
     req: axum::extract::Request,
 ) -> Response {
     let method = req.method().clone();
+
+    // OPTIONS is deliberately public so clients can discover DAV support.
+    // Every other method is fail-closed, including methods added in the future.
+    if method != http::Method::OPTIONS && !state.credential.authorizes(req.headers()) {
+        return Response::builder()
+            .status(StatusCode::UNAUTHORIZED)
+            .header("WWW-Authenticate", "Basic realm=\"AxiomVault WebDAV\"")
+            .header("Content-Length", "0")
+            .body(Body::empty())
+            .unwrap();
+    }
+
     let path = req.uri().path().to_string();
     let depth = req
         .headers()

--- a/core/webdav/src/lib.rs
+++ b/core/webdav/src/lib.rs
@@ -5,10 +5,11 @@
 //! on write and decrypted on read.
 //!
 //! # Security
-//! - Binds only to `127.0.0.1` (never `0.0.0.0`)
-//! - No authentication layer (vault is already password-protected)
+//! - Binds only to loopback IP addresses
+//! - Requires a random, session-scoped HTTP Basic credential
 //! - All operations go through `VaultOperations` which handles encryption
 
+pub mod auth;
 pub mod config;
 pub mod handler;
 pub mod xml;
@@ -22,6 +23,7 @@ use tracing::debug;
 use axiomvault_common::Result;
 use axiomvault_vault::VaultSession;
 
+pub use auth::{WebDavCredential, WEBDAV_USERNAME};
 pub use config::WebDavConfig;
 use handler::AppState;
 
@@ -29,12 +31,22 @@ use handler::AppState;
 pub struct WebDavServer {
     session: Arc<VaultSession>,
     config: WebDavConfig,
+    credential: Arc<WebDavCredential>,
 }
 
 impl WebDavServer {
     /// Create a new WebDAV server.
     pub fn new(session: Arc<VaultSession>, config: WebDavConfig) -> Self {
-        Self { session, config }
+        Self {
+            session,
+            config,
+            credential: Arc::new(WebDavCredential::generate()),
+        }
+    }
+
+    /// Return the random credential for this server session.
+    pub fn credential(&self) -> &WebDavCredential {
+        &self.credential
     }
 
     /// Start the server. Runs until the future is cancelled or the listener fails.
@@ -45,13 +57,14 @@ impl WebDavServer {
         let state = AppState {
             session: self.session.clone(),
             max_body_size: self.config.max_body_size,
+            credential: self.credential.clone(),
         };
 
         let app = Router::new()
             .fallback(handler::handle_request)
             .with_state(state);
 
-        let addr = self.config.socket_addr();
+        let addr = self.config.validated_socket_addr()?;
         debug!("Binding WebDAV server");
 
         let listener = TcpListener::bind(&addr).await?;
@@ -77,6 +90,7 @@ mod tests {
     use axiomvault_crypto::KdfParams;
     use axiomvault_storage::{MemoryProvider, StorageProvider};
     use axiomvault_vault::{VaultConfig, VaultOperations, VaultTree};
+    use base64::Engine;
     use http::Method;
 
     /// Helper to create a test session with an in-memory storage provider.
@@ -110,8 +124,8 @@ mod tests {
         listener.local_addr().unwrap().port()
     }
 
-    /// Start a WebDAV server in the background and return its base URL.
-    async fn start_test_server(session: Arc<VaultSession>) -> String {
+    /// Start a WebDAV server in the background and return its URL and password.
+    async fn start_test_server(session: Arc<VaultSession>) -> (String, String) {
         let port = free_port().await;
         let config = WebDavConfig {
             bind_address: "127.0.0.1".to_string(),
@@ -120,12 +134,53 @@ mod tests {
         };
         let server = WebDavServer::new(session, config);
         let url = server.url();
+        let password = server.credential().password().to_owned();
         tokio::spawn(async move {
             let _ = server.start().await;
         });
         // Give the server a moment to bind
         tokio::time::sleep(std::time::Duration::from_millis(50)).await;
-        url
+        (url, password)
+    }
+
+    fn authenticated_client(password: &str) -> reqwest::Client {
+        let encoded = base64::engine::general_purpose::STANDARD
+            .encode(format!("{}:{}", WEBDAV_USERNAME, password));
+        let mut headers = reqwest::header::HeaderMap::new();
+        headers.insert(
+            reqwest::header::AUTHORIZATION,
+            format!("Basic {encoded}").parse().unwrap(),
+        );
+        reqwest::Client::builder()
+            .default_headers(headers)
+            .build()
+            .unwrap()
+    }
+
+    #[tokio::test]
+    async fn non_loopback_bind_addresses_are_rejected_by_start() {
+        let session = create_test_session().await;
+
+        for bind_address in ["0.0.0.0", "::", "192.168.1.10", "203.0.113.10"] {
+            let server = WebDavServer::new(
+                session.clone(),
+                WebDavConfig {
+                    bind_address: bind_address.to_owned(),
+                    port: 0,
+                    ..Default::default()
+                },
+            );
+
+            let error = tokio::time::timeout(std::time::Duration::from_millis(100), server.start())
+                .await
+                .expect("non-loopback validation must happen before binding")
+                .unwrap_err();
+
+            assert!(
+                matches!(error, axiomvault_common::Error::InvalidInput(_)),
+                "{bind_address} returned {error:?}"
+            );
+        }
     }
 
     #[tokio::test]
@@ -141,9 +196,9 @@ mod tests {
         .await
         .unwrap();
 
-        let base_url = start_test_server(session).await;
+        let (base_url, password) = start_test_server(session).await;
 
-        let client = reqwest::Client::new();
+        let client = authenticated_client(&password);
         let resp = client
             .request(Method::from_bytes(b"PROPFIND").unwrap(), &base_url)
             .header("Depth", "1")
@@ -158,7 +213,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_get_file() {
+    async fn unauthenticated_vault_methods_are_rejected() {
         let session = create_test_session().await;
         let ops = VaultOperations::new(&session).unwrap();
         ops.create_file(
@@ -168,26 +223,98 @@ mod tests {
         .await
         .unwrap();
 
-        let base_url = start_test_server(session).await;
-
+        let (base_url, _) = start_test_server(session.clone()).await;
         let client = reqwest::Client::new();
-        let resp = client
-            .get(format!("{}/test.txt", base_url))
+
+        for (method, path) in [
+            ("PROPFIND", "/"),
+            ("GET", "/test.txt"),
+            ("HEAD", "/test.txt"),
+            ("PUT", "/test.txt"),
+            ("MKCOL", "/new-directory"),
+            ("DELETE", "/test.txt"),
+        ] {
+            let response = client
+                .request(
+                    Method::from_bytes(method.as_bytes()).unwrap(),
+                    format!("{base_url}{path}"),
+                )
+                .body("attacker-controlled")
+                .send()
+                .await
+                .unwrap();
+
+            assert_eq!(
+                response.status(),
+                401,
+                "{method} must require authentication"
+            );
+            assert_eq!(
+                response
+                    .headers()
+                    .get("www-authenticate")
+                    .and_then(|value| value.to_str().ok()),
+                Some("Basic realm=\"AxiomVault WebDAV\"")
+            );
+        }
+
+        assert_eq!(
+            ops.read_file(&axiomvault_common::VaultPath::parse("/test.txt").unwrap())
+                .await
+                .unwrap(),
+            b"decrypted content"
+        );
+        assert!(
+            !ops.exists(&axiomvault_common::VaultPath::parse("/new-directory").unwrap())
+                .await
+        );
+    }
+
+    #[tokio::test]
+    async fn wrong_password_is_rejected() {
+        let session = create_test_session().await;
+        let (base_url, _) = start_test_server(session).await;
+
+        let response = authenticated_client("wrong-password")
+            .get(format!("{base_url}/test.txt"))
             .send()
             .await
             .unwrap();
 
-        assert_eq!(resp.status(), 200);
-        let body = resp.bytes().await.unwrap();
-        assert_eq!(&body[..], b"decrypted content");
+        assert_eq!(response.status(), 401);
+    }
+
+    #[tokio::test]
+    async fn correct_password_allows_decrypted_get() {
+        let session = create_test_session().await;
+        let ops = VaultOperations::new(&session).unwrap();
+        ops.create_file(
+            &axiomvault_common::VaultPath::parse("/secret.txt").unwrap(),
+            b"decrypted content",
+        )
+        .await
+        .unwrap();
+        let (base_url, password) = start_test_server(session).await;
+
+        let response = authenticated_client(&password)
+            .get(format!("{base_url}/secret.txt"))
+            .send()
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), 200);
+        assert_eq!(
+            response.bytes().await.unwrap(),
+            b"decrypted content".as_slice()
+        );
     }
 
     #[tokio::test]
     async fn test_put_create_file() {
         let session = create_test_session().await;
-        let base_url = start_test_server(session.clone()).await;
+        let (base_url, password) = start_test_server(session.clone()).await;
 
-        let client = reqwest::Client::new();
+        let client = authenticated_client(&password);
 
         // PUT a new file
         let resp = client
@@ -222,9 +349,9 @@ mod tests {
         .await
         .unwrap();
 
-        let base_url = start_test_server(session).await;
+        let (base_url, password) = start_test_server(session).await;
 
-        let client = reqwest::Client::new();
+        let client = authenticated_client(&password);
         let resp = client
             .put(format!("{}/existing.txt", base_url))
             .body("updated content")
@@ -255,9 +382,9 @@ mod tests {
         .await
         .unwrap();
 
-        let base_url = start_test_server(session).await;
+        let (base_url, password) = start_test_server(session).await;
 
-        let client = reqwest::Client::new();
+        let client = authenticated_client(&password);
         let resp = client
             .delete(format!("{}/todelete.txt", base_url))
             .send()
@@ -279,9 +406,9 @@ mod tests {
     #[tokio::test]
     async fn test_mkcol_create_directory() {
         let session = create_test_session().await;
-        let base_url = start_test_server(session).await;
+        let (base_url, password) = start_test_server(session).await;
 
-        let client = reqwest::Client::new();
+        let client = authenticated_client(&password);
         let resp = client
             .request(
                 Method::from_bytes(b"MKCOL").unwrap(),
@@ -312,9 +439,9 @@ mod tests {
     #[tokio::test]
     async fn test_options() {
         let session = create_test_session().await;
-        let base_url = start_test_server(session).await;
+        let (base_url, password) = start_test_server(session).await;
 
-        let client = reqwest::Client::new();
+        let client = authenticated_client(&password);
         let resp = client
             .request(Method::OPTIONS, &base_url)
             .send()
@@ -333,9 +460,9 @@ mod tests {
     #[tokio::test]
     async fn test_unsupported_methods_return_501() {
         let session = create_test_session().await;
-        let base_url = start_test_server(session).await;
+        let (base_url, password) = start_test_server(session).await;
 
-        let client = reqwest::Client::new();
+        let client = authenticated_client(&password);
 
         for method_name in &["MOVE", "COPY", "LOCK", "UNLOCK"] {
             let resp = client
@@ -362,9 +489,9 @@ mod tests {
         .await
         .unwrap();
 
-        let base_url = start_test_server(session).await;
+        let (base_url, password) = start_test_server(session).await;
 
-        let client = reqwest::Client::new();
+        let client = authenticated_client(&password);
         let resp = client
             .head(format!("{}/headtest.txt", base_url))
             .send()

--- a/tools/cli/src/main.rs
+++ b/tools/cli/src/main.rs
@@ -416,7 +416,7 @@ enum Commands {
         target: Option<usize>,
     },
 
-    /// Serve vault contents over WebDAV on the loopback interface.
+    /// Serve vault contents over authenticated WebDAV on the loopback interface.
     Webdav {
         /// Path to the vault.
         #[arg(short, long)]
@@ -2437,6 +2437,9 @@ async fn cmd_webdav(path: &Path, port: u16) -> Result<()> {
     let url = server.url();
 
     println!("WebDAV server running at {}/", url);
+    println!("Username: {}", server.credential().username());
+    println!("Password: {}", server.credential().password());
+    println!("This random credential is valid only for this server session.");
     println!("Press Ctrl+C to stop.");
 
     server


### PR DESCRIPTION
## Summary
- enforce loopback-only IP binding in the core WebDAV server
- require a 256-bit random per-server HTTP Basic credential for every method except OPTIONS
- redact/zeroize credential material and display it only for explicit local client setup
- document the same-host credential threat model

Closes #211

## Validation
- `cargo test -p axiomvault-webdav -- --nocapture` — 22 passed
- `cargo clippy -p axiomvault-webdav --all-targets --no-deps -- -D warnings` — passed
- `cargo fmt --all -- --check` — passed
- regression coverage: unauthenticated/wrong-password requests, decrypted GET with correct auth, IPv4/IPv6 loopback, non-loopback rejection
