### PR TITLE
fix(security): keep cloud credentials local and secure plaintext outputs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -228,9 +228,11 @@ dependencies = [
 name = "axiomvault-common"
 version = "0.1.0"
 dependencies = [
+ "libc",
  "proptest",
  "serde",
  "serde_json",
+ "tempfile",
  "thiserror 2.0.18",
  "zeroize",
 ]

--- a/core/app/src/service.rs
+++ b/core/app/src/service.rs
@@ -564,10 +564,17 @@ impl AppService {
     /// Export a vault file to the local filesystem.
     pub async fn export_file(&self, vault_path: &str, local_path: &str) -> AppResult<()> {
         let content = self.read_file(vault_path).await?;
-
-        tokio::fs::write(local_path, content)
-            .await
-            .map_err(|e| AppError::Storage(format!("Failed to write local file: {}", e)))?;
+        let destination = std::path::PathBuf::from(local_path);
+        tokio::task::spawn_blocking(move || {
+            axiomvault_common::write_sensitive_file(
+                destination,
+                &content,
+                axiomvault_common::SensitiveFileMode::CreateNew,
+            )
+        })
+        .await
+        .map_err(|e| AppError::Storage(format!("Export task failed: {e}")))?
+        .map_err(|e| AppError::Storage(format!("Failed to write local file securely: {e}")))?;
 
         Ok(())
     }

--- a/core/app/tests/app_service_contract.rs
+++ b/core/app/tests/app_service_contract.rs
@@ -730,8 +730,9 @@ async fn close_wipes_index() {
 #[tokio::test]
 async fn import_and_export_file() {
     let svc = service_with_vault().await;
+    let local = tempfile::tempdir().unwrap();
 
-    let tmp = std::env::temp_dir().join("axiomvault_test_import.txt");
+    let tmp = local.path().join("import.txt");
     std::fs::write(&tmp, b"imported content").unwrap();
 
     svc.import_file(tmp.to_str().unwrap(), "/imported.txt")
@@ -741,17 +742,32 @@ async fn import_and_export_file() {
     let content = svc.read_file("/imported.txt").await.unwrap();
     assert_eq!(content, b"imported content");
 
-    let export_path = std::env::temp_dir().join("axiomvault_test_export.txt");
+    let export_path = local.path().join("export.txt");
     svc.export_file("/imported.txt", export_path.to_str().unwrap())
         .await
         .unwrap();
 
     let exported = std::fs::read(&export_path).unwrap();
     assert_eq!(exported, b"imported content");
+}
 
-    // Cleanup.
-    let _ = std::fs::remove_file(&tmp);
-    let _ = std::fs::remove_file(&export_path);
+#[tokio::test]
+async fn export_refuses_to_overwrite_existing_plaintext() {
+    let svc = service_with_vault().await;
+    svc.create_file("/secret.txt", b"vault secret")
+        .await
+        .unwrap();
+    let local = tempfile::tempdir().unwrap();
+    let destination = local.path().join("existing.txt");
+    std::fs::write(&destination, b"keep me").unwrap();
+
+    let error = svc
+        .export_file("/secret.txt", destination.to_str().unwrap())
+        .await
+        .unwrap_err();
+
+    assert!(matches!(error, AppError::Storage(_)));
+    assert_eq!(std::fs::read(destination).unwrap(), b"keep me");
 }
 
 #[tokio::test]

--- a/core/common/Cargo.toml
+++ b/core/common/Cargo.toml
@@ -12,3 +12,7 @@ zeroize.workspace = true
 
 [dev-dependencies]
 proptest.workspace = true
+tempfile.workspace = true
+
+[target.'cfg(unix)'.dev-dependencies]
+libc = "0.2"

--- a/core/common/src/lib.rs
+++ b/core/common/src/lib.rs
@@ -5,8 +5,10 @@
 
 pub mod error;
 pub mod health;
+pub mod secure_file;
 pub mod types;
 
 pub use error::{Error, Result};
 pub use health::{DiagnosticResult, HealthReport, HealthStatus, Severity};
+pub use secure_file::{write_sensitive_file, SensitiveFileMode};
 pub use types::{VaultId, VaultPath};

--- a/core/common/src/secure_file.rs
+++ b/core/common/src/secure_file.rs
@@ -1,0 +1,255 @@
+//! Atomic, restrictive writes for plaintext exports and credential files.
+
+#[cfg(unix)]
+use std::fs::OpenOptions;
+use std::fs::{self, File};
+use std::io::{self, Write};
+use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::time::{SystemTime, UNIX_EPOCH};
+
+static TEMP_COUNTER: AtomicU64 = AtomicU64::new(0);
+
+/// Controls whether an existing sensitive destination may be replaced.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SensitiveFileMode {
+    /// Atomically fail if any filesystem entry already exists at the path.
+    CreateNew,
+    /// Atomically replace an existing regular file; symlinks are rejected.
+    Replace,
+}
+
+struct TempDirGuard(PathBuf);
+
+impl Drop for TempDirGuard {
+    fn drop(&mut self) {
+        let _ = fs::remove_dir_all(&self.0);
+    }
+}
+
+fn create_private_temp_dir(parent: &Path) -> io::Result<TempDirGuard> {
+    for _ in 0..128 {
+        let nonce = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_nanos();
+        let count = TEMP_COUNTER.fetch_add(1, Ordering::Relaxed);
+        let path = parent.join(format!(
+            ".axiomvault-sensitive-{}-{nonce}-{count}",
+            std::process::id()
+        ));
+        let mut builder = fs::DirBuilder::new();
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::DirBuilderExt;
+            builder.mode(0o700);
+        }
+        match builder.create(&path) {
+            Ok(()) => return Ok(TempDirGuard(path)),
+            Err(error) if error.kind() == io::ErrorKind::AlreadyExists => continue,
+            Err(error) => return Err(error),
+        }
+    }
+    Err(io::Error::new(
+        io::ErrorKind::AlreadyExists,
+        "could not allocate private temporary directory",
+    ))
+}
+
+fn open_private_file(path: &Path) -> io::Result<File> {
+    #[cfg(not(unix))]
+    {
+        let _ = path;
+        return Err(io::Error::new(
+            io::ErrorKind::Unsupported,
+            "secure plaintext-file ACL creation is not implemented on this platform",
+        ));
+    }
+
+    #[cfg(unix)]
+    {
+        let mut options = OpenOptions::new();
+        options.write(true).create_new(true);
+        use std::os::unix::fs::OpenOptionsExt;
+        options.mode(0o600);
+        options.open(path)
+    }
+}
+
+fn sync_parent(parent: &Path) -> io::Result<()> {
+    #[cfg(unix)]
+    {
+        File::open(parent)?.sync_all()?;
+    }
+    Ok(())
+}
+
+fn write_sensitive_with<F>(destination: &Path, mode: SensitiveFileMode, writer: F) -> io::Result<()>
+where
+    F: FnOnce(&mut File) -> io::Result<()>,
+{
+    let parent = destination.parent().unwrap_or_else(|| Path::new("."));
+    let file_name = destination.file_name().ok_or_else(|| {
+        io::Error::new(io::ErrorKind::InvalidInput, "destination has no file name")
+    })?;
+
+    if mode == SensitiveFileMode::Replace {
+        match fs::symlink_metadata(destination) {
+            Ok(metadata) if metadata.file_type().is_symlink() => {
+                return Err(io::Error::new(
+                    io::ErrorKind::InvalidInput,
+                    "refusing to replace a symlink destination",
+                ));
+            }
+            Ok(metadata) if !metadata.is_file() => {
+                return Err(io::Error::new(
+                    io::ErrorKind::InvalidInput,
+                    "refusing to replace a non-file destination",
+                ));
+            }
+            Ok(_) => {}
+            Err(error) if error.kind() == io::ErrorKind::NotFound => {}
+            Err(error) => return Err(error),
+        }
+    }
+
+    let temp_dir = create_private_temp_dir(parent)?;
+    let temp_path = temp_dir.0.join(file_name);
+    let mut temp_file = open_private_file(&temp_path)?;
+    writer(&mut temp_file)?;
+    temp_file.sync_all()?;
+    drop(temp_file);
+
+    match mode {
+        SensitiveFileMode::CreateNew => {
+            fs::hard_link(&temp_path, destination)?;
+            fs::remove_file(&temp_path)?;
+        }
+        SensitiveFileMode::Replace => fs::rename(&temp_path, destination)?,
+    }
+    sync_parent(parent)?;
+    Ok(())
+}
+
+/// Write sensitive bytes atomically with mode `0600` on Unix.
+///
+/// A private `0700` temporary directory is created beside the destination,
+/// the file is fully written and fsynced, and only then is it published.
+/// `CreateNew` uses an atomic no-clobber link; `Replace` must be explicit and
+/// rejects symlink and non-file destinations.
+pub fn write_sensitive_file(
+    destination: impl AsRef<Path>,
+    bytes: &[u8],
+    mode: SensitiveFileMode,
+) -> io::Result<()> {
+    write_sensitive_with(destination.as_ref(), mode, |file| file.write_all(bytes))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::{Arc, Barrier, Mutex};
+
+    #[cfg(unix)]
+    static UMASK_LOCK: Mutex<()> = Mutex::new(());
+
+    #[test]
+    #[cfg(unix)]
+    fn permissive_umask_still_creates_mode_0600() {
+        use std::os::unix::fs::PermissionsExt;
+        let _lock = UMASK_LOCK.lock().unwrap();
+        // SAFETY: the process-global umask is serialized by UMASK_LOCK and restored below.
+        let old_umask = unsafe { libc::umask(0) };
+        let temp = tempfile::tempdir().unwrap();
+        let destination = temp.path().join("export");
+        let result = write_sensitive_file(&destination, b"plaintext", SensitiveFileMode::CreateNew);
+        // SAFETY: restore the exact umask captured while holding UMASK_LOCK.
+        unsafe { libc::umask(old_umask) };
+        result.unwrap();
+        assert_eq!(
+            fs::metadata(destination).unwrap().permissions().mode() & 0o777,
+            0o600
+        );
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn attacker_prepared_symlink_is_rejected() {
+        use std::os::unix::fs::symlink;
+        let temp = tempfile::tempdir().unwrap();
+        let victim = temp.path().join("victim");
+        fs::write(&victim, b"safe").unwrap();
+        let destination = temp.path().join("export");
+        symlink(&victim, &destination).unwrap();
+
+        assert!(
+            write_sensitive_file(&destination, b"secret", SensitiveFileMode::CreateNew).is_err()
+        );
+        assert!(write_sensitive_file(&destination, b"secret", SensitiveFileMode::Replace).is_err());
+        assert_eq!(fs::read(victim).unwrap(), b"safe");
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn concurrent_creation_has_exactly_one_winner() {
+        let temp = tempfile::tempdir().unwrap();
+        let destination = Arc::new(temp.path().join("export"));
+        let barrier = Arc::new(Barrier::new(3));
+        let mut threads = Vec::new();
+        for bytes in [b"first".as_slice(), b"second".as_slice()] {
+            let destination = destination.clone();
+            let barrier = barrier.clone();
+            threads.push(std::thread::spawn(move || {
+                barrier.wait();
+                write_sensitive_file(destination.as_ref(), bytes, SensitiveFileMode::CreateNew)
+            }));
+        }
+        barrier.wait();
+        let successes = threads
+            .into_iter()
+            .map(|thread| thread.join().unwrap())
+            .filter(Result::is_ok)
+            .count();
+        assert_eq!(successes, 1);
+        let content = fs::read(destination.as_ref()).unwrap();
+        assert!(content == b"first" || content == b"second");
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn write_failure_leaves_no_destination_or_temporary_plaintext() {
+        let temp = tempfile::tempdir().unwrap();
+        let destination = temp.path().join("export");
+        let error = write_sensitive_with(&destination, SensitiveFileMode::CreateNew, |file| {
+            file.write_all(b"partial secret")?;
+            Err(io::Error::other("sabotaged write"))
+        })
+        .unwrap_err();
+        assert_eq!(error.to_string(), "sabotaged write");
+        assert!(!destination.exists());
+        assert_eq!(fs::read_dir(temp.path()).unwrap().count(), 0);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn replacement_requires_explicit_intent_and_remains_restrictive() {
+        let temp = tempfile::tempdir().unwrap();
+        let destination = temp.path().join("export");
+        write_sensitive_file(&destination, b"old", SensitiveFileMode::CreateNew).unwrap();
+        assert!(write_sensitive_file(&destination, b"new", SensitiveFileMode::CreateNew).is_err());
+        assert_eq!(fs::read(&destination).unwrap(), b"old");
+        write_sensitive_file(&destination, b"new", SensitiveFileMode::Replace).unwrap();
+        assert_eq!(fs::read(&destination).unwrap(), b"new");
+    }
+
+    #[cfg(not(unix))]
+    #[test]
+    fn unsupported_acl_platform_fails_closed() {
+        let temp = tempfile::tempdir().unwrap();
+        let destination = temp.path().join("export");
+        let error = write_sensitive_file(&destination, b"secret", SensitiveFileMode::CreateNew)
+            .unwrap_err();
+        assert_eq!(error.kind(), io::ErrorKind::Unsupported);
+        assert!(!destination.exists());
+    }
+}

--- a/core/vault/src/config.rs
+++ b/core/vault/src/config.rs
@@ -12,6 +12,41 @@ use axiomvault_crypto::recovery::{
 use axiomvault_crypto::{KdfParams, MasterKey, Salt};
 use zeroize::Zeroizing;
 
+fn contains_oauth_credentials(value: &serde_json::Value) -> bool {
+    match value {
+        serde_json::Value::Object(entries) => entries.iter().any(|(key, value)| {
+            let normalized = key.to_ascii_lowercase().replace('-', "_");
+            matches!(
+                normalized.as_str(),
+                "tokens"
+                    | "auth_config"
+                    | "access_token"
+                    | "refresh_token"
+                    | "client_secret"
+                    | "authorization_code"
+                    | "code_verifier"
+            ) || contains_oauth_credentials(value)
+        }),
+        serde_json::Value::Array(values) => values.iter().any(contains_oauth_credentials),
+        _ => false,
+    }
+}
+
+fn serialize_provider_config<S>(
+    value: &serde_json::Value,
+    serializer: S,
+) -> std::result::Result<S::Ok, S::Error>
+where
+    S: serde::Serializer,
+{
+    if contains_oauth_credentials(value) {
+        return Err(serde::ser::Error::custom(
+            "OAuth credentials are forbidden in serialized vault configuration",
+        ));
+    }
+    value.serialize(serializer)
+}
+
 /// Vault format version for migration support.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
 pub struct VaultVersion {
@@ -79,6 +114,7 @@ pub struct VaultConfig {
     /// Storage provider type (e.g., "local", "gdrive").
     pub provider_type: String,
     /// Provider-specific configuration.
+    #[serde(serialize_with = "serialize_provider_config")]
     pub provider_config: serde_json::Value,
     /// Vault creation timestamp.
     pub created_at: DateTime<Utc>,
@@ -503,6 +539,31 @@ mod tests {
         let mk_from_recovery = config.verify_recovery_key(&rk).unwrap().unwrap();
 
         assert_eq!(mk_from_password.as_bytes(), mk_from_recovery.as_bytes());
+    }
+
+    #[test]
+    fn oauth_credentials_cannot_be_serialized_in_vault_config() {
+        let mut config = VaultConfig::new(
+            VaultId::new("cloud-secrets").unwrap(),
+            b"password",
+            "gdrive",
+            serde_json::json!({
+                "credential_schema": 1,
+                "credential_ref": "local:gdrive:test",
+                "folder_id": "folder"
+            }),
+            KdfParams::moderate(),
+        )
+        .unwrap()
+        .config;
+        config.provider_config["tokens"] = serde_json::json!({
+            "access_token": "must-never-serialize",
+            "refresh_token": "must-never-serialize",
+            "expires_at": "2099-01-01T00:00:00Z"
+        });
+
+        let error = serde_json::to_string(&config).unwrap_err();
+        assert!(error.to_string().contains("OAuth credentials"));
     }
 
     #[test]

--- a/core/vault/src/manager.rs
+++ b/core/vault/src/manager.rs
@@ -11,6 +11,51 @@ use axiomvault_crypto::KdfParams;
 use axiomvault_storage::{create_default_registry, ProviderRegistry, StorageProvider};
 use zeroize::Zeroizing;
 
+fn persisted_provider_config(
+    provider_type: &str,
+    runtime_config: &serde_json::Value,
+) -> Result<serde_json::Value> {
+    let (identity_key, provider_label) = match provider_type {
+        "gdrive" => ("folder_id", "Google Drive"),
+        "dropbox" => ("root_path", "Dropbox"),
+        "onedrive" => ("root_path", "OneDrive"),
+        _ => return Ok(runtime_config.clone()),
+    };
+    let identity = runtime_config
+        .get(identity_key)
+        .and_then(serde_json::Value::as_str)
+        .ok_or_else(|| {
+            Error::InvalidInput(format!("{provider_label} config requires '{identity_key}'"))
+        })?;
+    let credential_ref = runtime_config
+        .get("credential_ref")
+        .and_then(serde_json::Value::as_str)
+        .ok_or_else(|| {
+            Error::InvalidInput(format!(
+                "{provider_label} config requires local 'credential_ref'"
+            ))
+        })?;
+    Ok(serde_json::json!({
+        identity_key: identity,
+        "credential_ref": credential_ref,
+        "credential_schema": 1,
+    }))
+}
+
+fn is_oauth_cloud_provider(provider_type: &str) -> bool {
+    matches!(provider_type, "gdrive" | "dropbox" | "onedrive")
+}
+
+/// Resolves an opaque credential reference using local-only storage.
+///
+/// Implementations may use an OS keychain, keystore, Secret Service, or a
+/// private local file. Returned credentials are passed only to the provider
+/// factory and are never included in `vault.config`.
+pub trait LocalCredentialResolver: Send + Sync {
+    /// Resolve provider credentials for a non-secret persisted reference.
+    fn resolve(&self, provider_type: &str, credential_ref: &str) -> Result<serde_json::Value>;
+}
+
 /// Result of vault creation, containing the session and recovery words.
 pub struct VaultCreation {
     /// Active session for the newly created vault.
@@ -22,6 +67,7 @@ pub struct VaultCreation {
 /// Vault manager for creating and opening vaults.
 pub struct VaultManager {
     registry: ProviderRegistry,
+    credential_resolver: Option<Arc<dyn LocalCredentialResolver>>,
 }
 
 impl VaultManager {
@@ -29,12 +75,27 @@ impl VaultManager {
     pub fn new() -> Self {
         Self {
             registry: create_default_registry(),
+            credential_resolver: None,
         }
     }
 
     /// Create with custom registry.
     pub fn with_registry(registry: ProviderRegistry) -> Self {
-        Self { registry }
+        Self {
+            registry,
+            credential_resolver: None,
+        }
+    }
+
+    /// Create with a custom provider registry and local credential resolver.
+    pub fn with_registry_and_credential_resolver(
+        registry: ProviderRegistry,
+        credential_resolver: Arc<dyn LocalCredentialResolver>,
+    ) -> Self {
+        Self {
+            registry,
+            credential_resolver: Some(credential_resolver),
+        }
     }
 
     /// Get the provider registry.
@@ -45,6 +106,38 @@ impl VaultManager {
     /// Get mutable provider registry.
     pub fn registry_mut(&mut self) -> &mut ProviderRegistry {
         &mut self.registry
+    }
+
+    fn runtime_provider_config(
+        &self,
+        provider_type: &str,
+        provider_config: &serde_json::Value,
+    ) -> Result<serde_json::Value> {
+        if !is_oauth_cloud_provider(provider_type) || provider_config.get("tokens").is_some() {
+            return Ok(provider_config.clone());
+        }
+
+        let safe_config = persisted_provider_config(provider_type, provider_config)?;
+        let credential_ref = safe_config["credential_ref"]
+            .as_str()
+            .expect("persisted_provider_config validates credential_ref");
+        let resolver = self.credential_resolver.as_ref().ok_or_else(|| {
+            Error::InvalidInput(format!(
+                "Cloud credential reference '{credential_ref}' must be resolved by a local credential resolver"
+            ))
+        })?;
+        let credentials = resolver.resolve(provider_type, credential_ref)?;
+        let tokens = credentials.get("tokens").cloned().ok_or_else(|| {
+            Error::InvalidInput(format!(
+                "Local credential reference '{credential_ref}' did not resolve OAuth tokens"
+            ))
+        })?;
+        let mut runtime_config = safe_config;
+        runtime_config["tokens"] = tokens;
+        if let Some(auth_config) = credentials.get("auth_config") {
+            runtime_config["auth_config"] = auth_config.clone();
+        }
+        Ok(runtime_config)
     }
 
     /// Create a new vault.
@@ -59,15 +152,15 @@ impl VaultManager {
         provider_config: serde_json::Value,
         kdf_params: KdfParams,
     ) -> Result<VaultCreation> {
-        let provider = self
-            .registry
-            .resolve(provider_type, provider_config.clone())?;
+        let runtime_config = self.runtime_provider_config(provider_type, &provider_config)?;
+        let provider = self.registry.resolve(provider_type, runtime_config)?;
+        let persisted_config = persisted_provider_config(provider_type, &provider_config)?;
 
         let creation = VaultConfig::new(
             vault_id,
             password,
             provider_type,
-            provider_config,
+            persisted_config,
             kdf_params,
         )?;
 
@@ -118,7 +211,8 @@ impl VaultManager {
         provider_config: serde_json::Value,
         password: &[u8],
     ) -> Result<VaultSession> {
-        let provider = self.registry.resolve(provider_type, provider_config)?;
+        let runtime_config = self.runtime_provider_config(provider_type, &provider_config)?;
+        let provider = self.registry.resolve(provider_type, runtime_config)?;
 
         let config_path = VaultPath::parse(CONFIG_FILENAME)?;
         if !provider.exists(&config_path).await? {
@@ -126,13 +220,21 @@ impl VaultManager {
         }
 
         let config_bytes = provider.download(&config_path).await?;
-        let config = VaultConfig::from_bytes(&config_bytes)?;
+        let mut config = VaultConfig::from_bytes(&config_bytes)?;
 
         let master_key = config
             .verify_password(password)?
             .ok_or_else(|| Error::NotPermitted("Invalid password".to_string()))?;
 
         let tree = VaultSession::load_and_decrypt_tree(&provider, &master_key).await?;
+
+        if is_oauth_cloud_provider(provider_type) {
+            let safe_config = persisted_provider_config(provider_type, &provider_config)?;
+            if config.provider_config != safe_config {
+                config.provider_config = safe_config;
+                provider.upload(&config_path, config.to_bytes()?).await?;
+            }
+        }
 
         VaultSession::from_master_key(config, master_key, provider, tree)
     }
@@ -150,7 +252,8 @@ impl VaultManager {
         recovery_words: &str,
         new_password: &[u8],
     ) -> Result<VaultSession> {
-        let provider = self.registry.resolve(provider_type, provider_config)?;
+        let runtime_config = self.runtime_provider_config(provider_type, &provider_config)?;
+        let provider = self.registry.resolve(provider_type, runtime_config)?;
 
         let config_path = VaultPath::parse(CONFIG_FILENAME)?;
         if !provider.exists(&config_path).await? {
@@ -172,6 +275,9 @@ impl VaultManager {
 
         // Reset password in config. The master key itself doesn't change.
         config.reset_password(&recovery_key, new_password)?;
+        if is_oauth_cloud_provider(provider_type) {
+            config.provider_config = persisted_provider_config(provider_type, &provider_config)?;
+        }
 
         // Save updated config.
         let config_bytes = config.to_bytes()?;
@@ -187,7 +293,8 @@ impl VaultManager {
         provider_type: &str,
         provider_config: serde_json::Value,
     ) -> Result<bool> {
-        let provider = self.registry.resolve(provider_type, provider_config)?;
+        let runtime_config = self.runtime_provider_config(provider_type, &provider_config)?;
+        let provider = self.registry.resolve(provider_type, runtime_config)?;
         let config_path = VaultPath::parse(CONFIG_FILENAME)?;
         provider.exists(&config_path).await
     }
@@ -287,5 +394,295 @@ mod tests {
             .vault_exists("memory", serde_json::Value::Null)
             .await;
         assert!(exists.is_ok());
+    }
+
+    struct TestCredentialResolver;
+
+    impl LocalCredentialResolver for TestCredentialResolver {
+        fn resolve(&self, provider_type: &str, credential_ref: &str) -> Result<serde_json::Value> {
+            assert_eq!(provider_type, "gdrive");
+            assert_eq!(credential_ref, "local:gdrive:resolved");
+            Ok(serde_json::json!({
+                "tokens": {
+                    "access_token": "resolver-access-secret",
+                    "refresh_token": "resolver-refresh-secret",
+                    "expires_at": "2099-01-01T00:00:00Z"
+                },
+                "auth_config": {
+                    "client_id": "client-id",
+                    "client_secret": "resolver-client-secret",
+                    "redirect_url": "http://localhost/callback"
+                }
+            }))
+        }
+    }
+
+    #[tokio::test]
+    async fn opening_legacy_cloud_config_migrates_and_strips_embedded_credentials() {
+        let storage = Arc::new(axiomvault_storage::MemoryProvider::new());
+        let runtime_config = serde_json::json!({
+            "folder_id": "legacy-folder",
+            "credential_ref": "local:gdrive:resolved",
+            "tokens": {
+                "access_token": "initial-local-access",
+                "refresh_token": "initial-local-refresh",
+                "expires_at": "2099-01-01T00:00:00Z"
+            }
+        });
+        let mut create_registry = ProviderRegistry::new();
+        let create_storage = storage.clone();
+        create_registry
+            .register("gdrive", Box::new(move |_| Ok(create_storage.clone())))
+            .unwrap();
+        let create_manager = VaultManager::with_registry(create_registry);
+        let creation = create_manager
+            .create_vault(
+                VaultId::new("legacy-cloud").unwrap(),
+                b"password",
+                "gdrive",
+                runtime_config,
+                KdfParams::moderate(),
+            )
+            .await
+            .unwrap();
+
+        let mut legacy: serde_json::Value =
+            serde_json::from_slice(&creation.session.config().to_bytes().unwrap()).unwrap();
+        legacy["provider_config"] = serde_json::json!({
+            "folder_id": "legacy-folder",
+            "tokens": {
+                "access_token": "legacy-uploaded-access-secret",
+                "refresh_token": "legacy-uploaded-refresh-secret",
+                "expires_at": "2099-01-01T00:00:00Z"
+            },
+            "auth_config": {
+                "client_id": "legacy-client-id",
+                "client_secret": "legacy-uploaded-client-secret",
+                "redirect_url": "http://localhost/callback"
+            }
+        });
+        storage
+            .upload(
+                &VaultPath::parse(CONFIG_FILENAME).unwrap(),
+                serde_json::to_vec(&legacy).unwrap(),
+            )
+            .await
+            .unwrap();
+        drop(creation);
+
+        let mut open_registry = ProviderRegistry::new();
+        let open_storage = storage.clone();
+        open_registry
+            .register("gdrive", Box::new(move |_| Ok(open_storage.clone())))
+            .unwrap();
+        let open_manager = VaultManager::with_registry_and_credential_resolver(
+            open_registry,
+            Arc::new(TestCredentialResolver),
+        );
+        let safe_config = serde_json::json!({
+            "credential_schema": 1,
+            "credential_ref": "local:gdrive:resolved",
+            "folder_id": "legacy-folder"
+        });
+
+        let session = open_manager
+            .open_vault("gdrive", safe_config.clone(), b"password")
+            .await
+            .unwrap();
+        assert_eq!(session.config().provider_config, safe_config);
+        let migrated = storage
+            .download(&VaultPath::parse(CONFIG_FILENAME).unwrap())
+            .await
+            .unwrap();
+        let migrated = String::from_utf8(migrated).unwrap();
+        assert!(!migrated.contains("legacy-uploaded-access-secret"));
+        assert!(!migrated.contains("legacy-uploaded-refresh-secret"));
+        assert!(!migrated.contains("legacy-uploaded-client-secret"));
+        assert!(migrated.contains("local:gdrive:resolved"));
+    }
+
+    #[tokio::test]
+    async fn injected_local_credential_resolver_supplies_runtime_secrets_only() {
+        let storage = Arc::new(axiomvault_storage::MemoryProvider::new());
+        let observed_runtime = Arc::new(std::sync::Mutex::new(None));
+        let observed = observed_runtime.clone();
+        let resolved = storage.clone();
+        let mut registry = ProviderRegistry::new();
+        registry
+            .register(
+                "gdrive",
+                Box::new(move |config| {
+                    *observed.lock().unwrap() = Some(config);
+                    Ok(resolved.clone())
+                }),
+            )
+            .unwrap();
+        let manager = VaultManager::with_registry_and_credential_resolver(
+            registry,
+            Arc::new(TestCredentialResolver),
+        );
+        let safe_config = serde_json::json!({
+            "credential_schema": 1,
+            "credential_ref": "local:gdrive:resolved",
+            "folder_id": "remote-folder"
+        });
+
+        manager
+            .create_vault(
+                VaultId::new("resolved-local-credential").unwrap(),
+                b"password",
+                "gdrive",
+                safe_config,
+                KdfParams::moderate(),
+            )
+            .await
+            .unwrap();
+
+        let runtime = observed_runtime.lock().unwrap().clone().unwrap();
+        assert_eq!(runtime["tokens"]["access_token"], "resolver-access-secret");
+        let uploaded = storage
+            .download(&VaultPath::parse(CONFIG_FILENAME).unwrap())
+            .await
+            .unwrap();
+        let uploaded = String::from_utf8(uploaded).unwrap();
+        assert!(!uploaded.contains("resolver-access-secret"));
+        assert!(!uploaded.contains("resolver-refresh-secret"));
+        assert!(!uploaded.contains("resolver-client-secret"));
+    }
+
+    #[tokio::test]
+    async fn unresolved_cloud_credential_reference_is_rejected_explicitly() {
+        let manager = VaultManager::new();
+        let error = manager
+            .create_vault(
+                VaultId::new("missing-local-credential").unwrap(),
+                b"password",
+                "gdrive",
+                serde_json::json!({
+                    "credential_schema": 1,
+                    "credential_ref": "local:gdrive:missing",
+                    "folder_id": "remote-folder"
+                }),
+                KdfParams::moderate(),
+            )
+            .await
+            .err()
+            .expect("an unresolved local credential reference must fail");
+
+        assert!(
+            error.to_string().contains("credential reference"),
+            "unexpected error: {error}"
+        );
+    }
+
+    #[tokio::test]
+    async fn sibling_cloud_vault_uploads_exclude_oauth_credentials() {
+        for (provider_type, identity_key, identity_value) in [
+            ("dropbox", "root_path", "/AxiomVault"),
+            ("onedrive", "root_path", "/AxiomVault"),
+        ] {
+            let storage = Arc::new(axiomvault_storage::MemoryProvider::new());
+            let mut registry = ProviderRegistry::new();
+            let resolved = storage.clone();
+            registry
+                .register(provider_type, Box::new(move |_| Ok(resolved.clone())))
+                .unwrap();
+            let manager = VaultManager::with_registry(registry);
+            let mut provider_config = serde_json::json!({
+                "credential_ref": format!("local:{provider_type}:test"),
+                "tokens": {
+                    "access_token": format!("{provider_type}-access-secret"),
+                    "refresh_token": format!("{provider_type}-refresh-secret"),
+                    "expires_at": "2099-01-01T00:00:00Z"
+                },
+                "auth_config": {
+                    "client_id": "client-id",
+                    "client_secret": format!("{provider_type}-client-secret"),
+                    "redirect_url": "http://localhost/callback"
+                }
+            });
+            provider_config[identity_key] = serde_json::json!(identity_value);
+
+            manager
+                .create_vault(
+                    VaultId::new(format!("{provider_type}-test")).unwrap(),
+                    b"password",
+                    provider_type,
+                    provider_config,
+                    KdfParams::moderate(),
+                )
+                .await
+                .unwrap();
+
+            let bytes = storage
+                .download(&VaultPath::parse(CONFIG_FILENAME).unwrap())
+                .await
+                .unwrap();
+            let uploaded = String::from_utf8(bytes).unwrap();
+            assert!(!uploaded.contains(&format!("{provider_type}-access-secret")));
+            assert!(!uploaded.contains(&format!("{provider_type}-refresh-secret")));
+            assert!(!uploaded.contains(&format!("{provider_type}-client-secret")));
+            let config = VaultConfig::from_bytes(uploaded.as_bytes()).unwrap();
+            assert_eq!(config.provider_config[identity_key], identity_value);
+            assert_eq!(config.provider_config["credential_schema"], 1);
+            assert_eq!(
+                config.provider_config["credential_ref"],
+                format!("local:{provider_type}:test")
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn cloud_vault_upload_excludes_google_oauth_credentials() {
+        let storage = Arc::new(axiomvault_storage::MemoryProvider::new());
+        let mut registry = ProviderRegistry::new();
+        let resolved = storage.clone();
+        registry
+            .register("gdrive", Box::new(move |_| Ok(resolved.clone())))
+            .unwrap();
+        let manager = VaultManager::with_registry(registry);
+        let provider_config = serde_json::json!({
+            "folder_id": "remote-folder",
+            "credential_ref": "local:gdrive:test",
+            "tokens": {
+                "access_token": "uploaded-access-secret",
+                "refresh_token": "uploaded-refresh-secret",
+                "expires_at": "2099-01-01T00:00:00Z"
+            },
+            "auth_config": {
+                "client_id": "client-id",
+                "client_secret": "uploaded-client-secret",
+                "redirect_url": "http://localhost/callback"
+            }
+        });
+
+        manager
+            .create_vault(
+                VaultId::new("cloud-test").unwrap(),
+                b"password",
+                "gdrive",
+                provider_config,
+                KdfParams::moderate(),
+            )
+            .await
+            .unwrap();
+
+        let bytes = storage
+            .download(&VaultPath::parse(CONFIG_FILENAME).unwrap())
+            .await
+            .unwrap();
+        let uploaded = String::from_utf8(bytes).unwrap();
+        assert!(!uploaded.contains("uploaded-access-secret"));
+        assert!(!uploaded.contains("uploaded-refresh-secret"));
+        assert!(!uploaded.contains("uploaded-client-secret"));
+        let config = VaultConfig::from_bytes(uploaded.as_bytes()).unwrap();
+        assert_eq!(
+            config.provider_config,
+            serde_json::json!({
+                "credential_schema": 1,
+                "credential_ref": "local:gdrive:test",
+                "folder_id": "remote-folder"
+            })
+        );
     }
 }

--- a/tools/cli/src/main.rs
+++ b/tools/cli/src/main.rs
@@ -887,14 +887,23 @@ async fn cmd_extract(vault_path: &Path, source: &str, dest: &Path) -> Result<()>
         .await
         .context("Failed to read file from vault")?;
 
-    tokio::fs::write(dest, &content)
-        .await
-        .context("Failed to write output file")?;
+    let output = dest.to_path_buf();
+    let content_len = content.len();
+    tokio::task::spawn_blocking(move || {
+        axiomvault_common::write_sensitive_file(
+            output,
+            &content,
+            axiomvault_common::SensitiveFileMode::CreateNew,
+        )
+    })
+    .await
+    .context("Secure output task failed")?
+    .context("Failed to create output file securely")?;
 
     println!(
         "File extracted successfully: {} ({} bytes)",
         dest.display(),
-        content.len()
+        content_len
     );
 
     Ok(())
@@ -1359,16 +1368,17 @@ async fn cmd_gdrive_auth(
     let tokens_json =
         serde_json::to_string_pretty(&tokens).context("Failed to serialize tokens")?;
 
-    tokio::fs::write(output, &tokens_json)
-        .await
-        .context("Failed to write tokens file")?;
-
-    #[cfg(unix)]
-    {
-        use std::os::unix::fs::PermissionsExt;
-        let perms = std::fs::Permissions::from_mode(0o600);
-        std::fs::set_permissions(output, perms).context("Failed to set token file permissions")?;
-    }
+    let token_path = output.to_path_buf();
+    tokio::task::spawn_blocking(move || {
+        axiomvault_common::write_sensitive_file(
+            token_path,
+            tokens_json.as_bytes(),
+            axiomvault_common::SensitiveFileMode::CreateNew,
+        )
+    })
+    .await
+    .context("Secure token-write task failed")?
+    .context("Failed to create tokens file securely")?;
 
     println!();
     println!("Authentication successful!");
@@ -1417,8 +1427,10 @@ async fn cmd_gdrive_create(
         auth_config: None,
     };
 
-    let provider_config =
+    let mut provider_config =
         serde_json::to_value(gdrive_config).context("Failed to serialize GDrive config")?;
+    provider_config["credential_ref"] =
+        serde_json::Value::String(format!("local:gdrive:{folder_id}"));
 
     let creation = manager
         .create_vault(vault_id, &password, "gdrive", provider_config, kdf_params)
@@ -1453,8 +1465,10 @@ async fn cmd_gdrive_open(folder_id: &str, tokens_path: &Path) -> Result<()> {
         auth_config: None,
     };
 
-    let provider_config =
+    let mut provider_config =
         serde_json::to_value(gdrive_config).context("Failed to serialize GDrive config")?;
+    provider_config["credential_ref"] =
+        serde_json::Value::String(format!("local:gdrive:{folder_id}"));
 
     let manager = VaultManager::new();
 


### PR DESCRIPTION
## Summary
- persist only non-secret cloud provider identity plus an opaque local `credential_ref`
- resolve OAuth tokens/client configuration at runtime through a local credential resolver
- reject serialization of embedded OAuth credentials and sanitize legacy uploaded configs after authenticated open/recovery
- make CLI extraction, AppService export, and OAuth token writes atomic/no-clobber with `0600` files and symlink protection
- fail closed where restrictive plaintext-file ACL creation is unavailable

Closes #210
Closes #216

## Validation
- vault manager credential regression tests: 8 passed
- credential serialization regression: passed
- secure-file race/umask/symlink/failure tests: 5 passed
- AppService secure export tests: passed
- `cargo check -p axiomvault-cli` — passed
- affected crates Clippy with `-D warnings` — passed after rebase to current master
- `cargo fmt --all -- --check` and `git diff --check` — passed

## Security notes
No credential values are included in this PR. Legacy cloud config is rewritten only after password authentication and successful tree decryption. Runtime credentials never enter the portable `VaultConfig`.
